### PR TITLE
Allow Ruby 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ rvm:
 - 2.7
 - 2.6
 - 2.5
-- 2.4
 before_install:
 - gem install bundler -v $(grep -F "BUNDLED WITH" -A 1 "${BUNDLE_GEMFILE:-Gemfile}.lock" | tail -1)
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 sudo: false
 language: ruby
 rvm:
+- 3.0
+- 2.7
+- 2.6
 - 2.5
 - 2.4
 before_install:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,6 +26,7 @@ GEM
     rack (2.2.3)
     rake (12.3.3)
     redis (4.2.5)
+    rexml (3.2.4)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
@@ -49,11 +50,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.16)
+  bundler (~> 2.2)
   rake (~> 12.3)
+  rexml (~> 3.2)
   rspec (~> 3.7)
   sidekiq-cloudwatchmetrics!
   timecop (~> 0.9)
 
 BUNDLED WITH
-   1.17.3
+   2.2.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,17 +3,17 @@ PATH
   specs:
     sidekiq-cloudwatchmetrics (1.2.0)
       aws-sdk-cloudwatch (~> 1.6)
-      sidekiq (~> 5.0)
+      sidekiq (>= 5.0, < 7.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     aws-eventstream (1.1.0)
-    aws-partitions (1.414.0)
+    aws-partitions (1.417.0)
     aws-sdk-cloudwatch (1.47.0)
       aws-sdk-core (~> 3, >= 3.109.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-core (3.110.0)
+    aws-sdk-core (3.111.2)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
@@ -24,10 +24,8 @@ GEM
     diff-lcs (1.3)
     jmespath (1.4.0)
     rack (2.2.3)
-    rack-protection (2.1.0)
-      rack
     rake (12.3.3)
-    redis (4.1.4)
+    redis (4.2.5)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
@@ -41,11 +39,10 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.0)
-    sidekiq (5.2.9)
-      connection_pool (~> 2.2, >= 2.2.2)
+    sidekiq (6.1.2)
+      connection_pool (>= 2.2.2)
       rack (~> 2.0)
-      rack-protection (>= 1.5.0)
-      redis (>= 3.3.5, < 4.2)
+      redis (>= 4.2.0)
     timecop (0.9.1)
 
 PLATFORMS

--- a/sidekiq-cloudwatchmetrics.gemspec
+++ b/sidekiq-cloudwatchmetrics.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = Dir["README.md", "LICENSE", "lib/**/*.rb"]
 
-  spec.required_ruby_version = "~> 2.4"
+  spec.required_ruby_version = ">= 2.4"
 
   spec.add_runtime_dependency "sidekiq", "~> 5.0"
   spec.add_runtime_dependency "aws-sdk-cloudwatch", "~> 1.6"

--- a/sidekiq-cloudwatchmetrics.gemspec
+++ b/sidekiq-cloudwatchmetrics.gemspec
@@ -22,8 +22,9 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "sidekiq", ">= 5.0", "< 7.0"
   spec.add_runtime_dependency "aws-sdk-cloudwatch", "~> 1.6"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "rake", "~> 12.3"
   spec.add_development_dependency "rspec", "~> 3.7"
   spec.add_development_dependency "timecop", "~> 0.9"
+  spec.add_development_dependency "rexml", "~> 3.2"
 end

--- a/sidekiq-cloudwatchmetrics.gemspec
+++ b/sidekiq-cloudwatchmetrics.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.4"
 
-  spec.add_runtime_dependency "sidekiq", "~> 5.0"
+  spec.add_runtime_dependency "sidekiq", ">= 5.0", "< 7.0"
   spec.add_runtime_dependency "aws-sdk-cloudwatch", "~> 1.6"
 
   spec.add_development_dependency "bundler", "~> 1.16"


### PR DESCRIPTION
- Relax required_ruby_version to allow 3.0.0
- Test newer ruby versions on travis