### PR TITLE
Fix Aws::CloudWatch::Errors::InvalidParameterValue on startup

### DIFF
--- a/lib/sidekiq/cloudwatchmetrics.rb
+++ b/lib/sidekiq/cloudwatchmetrics.rb
@@ -217,6 +217,8 @@ module Sidekiq::CloudWatchMetrics
 
     # Returns busy / concurrency averaged across processes (for scaling)
     private def calculate_utilization(processes)
+      return 0.0 if processes.empty?
+
       processes.map do |process|
         process["busy"] / process["concurrency"].to_f
       end.sum / processes.size.to_f

--- a/spec/sidekiq/cloudwatchmetrics_spec.rb
+++ b/spec/sidekiq/cloudwatchmetrics_spec.rb
@@ -292,6 +292,25 @@ RSpec.describe Sidekiq::CloudWatchMetrics do
           end
         end
       end
+
+      context "when there are no processes yet" do
+        let(:processes) { [] }
+
+        it "publishes metrics including a utilization of 0 (not NaN)" do
+          Timecop.freeze(now = Time.now) do
+            publisher.publish
+
+            expect(client).to have_received(:put_metric_data) { |metrics|
+              expect(metrics[:metric_data]).to include({
+                metric_name: "Utilization",
+                timestamp: now,
+                value: 0.0,
+                unit: "Percent",
+              })
+            }
+          end
+        end
+      end
     end
 
     describe "#stop" do

--- a/spec/sidekiq/cloudwatchmetrics_spec.rb
+++ b/spec/sidekiq/cloudwatchmetrics_spec.rb
@@ -296,17 +296,12 @@ RSpec.describe Sidekiq::CloudWatchMetrics do
       context "when there are no processes yet" do
         let(:processes) { [] }
 
-        it "publishes metrics including a utilization of 0 (not NaN)" do
+        it "does not publish Utilization (to avoid NaN values)" do
           Timecop.freeze(now = Time.now) do
             publisher.publish
 
             expect(client).to have_received(:put_metric_data) { |metrics|
-              expect(metrics[:metric_data]).to include({
-                metric_name: "Utilization",
-                timestamp: now,
-                value: 0.0,
-                unit: "Percent",
-              })
+              expect(metrics[:metric_data]).not_to include(hash_including(metric_name: "Utilization"))
             }
           end
         end


### PR DESCRIPTION
Sidekiq API is updated every [5 seconds](https://github.com/mperham/sidekiq/wiki/API#processes). If the list of processes is empty and Sidekiq just booted up, the first metric data collection fails with 
```
Aws::CloudWatch::Errors::InvalidParameterValue: The value � for parameter MetricData.member.11.Value is invalid.
```

This is caused by a `0 / 0.0` division in https://github.com/sj26/sidekiq-cloudwatchmetrics/blob/cf431b4ae6a50c4ba78082a6a9dfe6cb0de5b2ec/lib/sidekiq/cloudwatchmetrics.rb#L203-L207

The Utilization metric in this case looks like:
```ruby
{:metric_name=>"Utilization", :timestamp=>2021-03-01 09:41:08 +1100, :value=>NaN, :unit=>"Percent"}
```

Lots of spec changes are mostly caused by consolidating common variables and `Timecop` blocks. Happy to revert if it breaks the code style of this project.