### PR TITLE
Additional Utilization Cloudwatch Metric for Sidekiq::Process Tag

### DIFF
--- a/lib/sidekiq/cloudwatchmetrics.rb
+++ b/lib/sidekiq/cloudwatchmetrics.rb
@@ -156,6 +156,8 @@ module Sidekiq::CloudWatchMetrics
           value: process["busy"] / process["concurrency"].to_f * 100.0,
           unit: "Percent",
         }
+
+        metrics << {}
       end
 
       queues.each do |(queue_name, queue_size)|
@@ -183,7 +185,6 @@ module Sidekiq::CloudWatchMetrics
           metric[:dimensions] = (metric[:dimensions] || []) + @additional_dimensions
         end
       end
-
       # We can only put 20 metrics at a time
       metrics.each_slice(20) do |some_metrics|
         @client.put_metric_data(

--- a/lib/sidekiq/cloudwatchmetrics.rb
+++ b/lib/sidekiq/cloudwatchmetrics.rb
@@ -157,7 +157,13 @@ module Sidekiq::CloudWatchMetrics
           unit: "Percent",
         }
 
-        metrics << {}
+        metrics << {
+          metric_name: "Utilization",
+          dimensions: [{name: "Tag", value: process["tag"]}],
+          timestamp: now,
+          value: process["busy"] / process["concurrency"].to_f * 100.0,
+          unit: "Percent",
+        }
       end
 
       queues.each do |(queue_name, queue_size)|

--- a/spec/sidekiq/cloudwatchmetrics_spec.rb
+++ b/spec/sidekiq/cloudwatchmetrics_spec.rb
@@ -62,8 +62,8 @@ RSpec.describe Sidekiq::CloudWatchMetrics do
           )
           allow(Sidekiq::Stats).to receive(:new).and_return(stats)
           processes = [
-            Sidekiq::Process.new("busy" => 5, "concurrency" => 10, "hostname" => "foo"),
-            Sidekiq::Process.new("busy" => 2, "concurrency" => 20, "hostname" => "bar"),
+            Sidekiq::Process.new("busy" => 5, "concurrency" => 10, "hostname" => "foo", "tag" => "sidekiq-high"),
+            Sidekiq::Process.new("busy" => 2, "concurrency" => 20, "hostname" => "bar", "tag" => "sidekiq-low"),
           ]
           allow(Sidekiq::ProcessSet).to receive(:new).and_return(processes)
           allow(Sidekiq::Queue).to receive(:new).with(/foo|bar|baz/).and_return(double(latency: 1.23))
@@ -145,7 +145,13 @@ RSpec.describe Sidekiq::CloudWatchMetrics do
                 unit: "Percent",
                 value: 50.0,
               },
-              {},
+              {
+                metric_name: "Utilization",
+                dimensions: [{name: "Tag", value: "sidekiq-high"}],
+                timestamp: now,
+                unit: "Percent",
+                value: 50.0,
+              },
               {
                 metric_name: "Utilization",
                 dimensions: [{name: "Hostname", value: "bar"}],
@@ -153,7 +159,13 @@ RSpec.describe Sidekiq::CloudWatchMetrics do
                 unit: "Percent",
                 value: 10.0,
               },
-              {},
+              {
+                metric_name: "Utilization",
+                dimensions: [{name: "Tag", value: "sidekiq-low"}],
+                timestamp: now,
+                unit: "Percent",
+                value: 10.0,
+              },
               {
                 metric_name: "QueueSize",
                 dimensions: [{name: "QueueName", value: "foo"}],
@@ -235,8 +247,8 @@ RSpec.describe Sidekiq::CloudWatchMetrics do
           )
           allow(Sidekiq::Stats).to receive(:new).and_return(stats)
           processes = [
-            Sidekiq::Process.new("busy" => 5, "concurrency" => 10, "hostname" => "foo"),
-            Sidekiq::Process.new("busy" => 2, "concurrency" => 20, "hostname" => "bar"),
+            Sidekiq::Process.new("busy" => 5, "concurrency" => 10, "hostname" => "foo", "tag" => "sidekiq-high"),
+            Sidekiq::Process.new("busy" => 2, "concurrency" => 20, "hostname" => "bar", "tag" => "sidekiq-low"),
           ]
           allow(Sidekiq::ProcessSet).to receive(:new).and_return(processes)
           allow(Sidekiq::Queue).to receive(:new).with(/foo|bar|baz/).and_return(double(latency: 1.23))
@@ -345,9 +357,13 @@ RSpec.describe Sidekiq::CloudWatchMetrics do
                 value: 50.0,
               },
               {
-                dimensions: [
-                  {name: "appCluster", value: "1"},
-                  {name: "type", value: "foo"}],
+                metric_name: "Utilization",
+                dimensions: [{name: "Tag", value: "sidekiq-high"},
+                             {name: "appCluster", value: "1"},
+                             {name: "type", value: "foo"}],
+                timestamp: now,
+                unit: "Percent",
+                value: 50.0,
               },
               {
                 metric_name: "Utilization",
@@ -359,9 +375,13 @@ RSpec.describe Sidekiq::CloudWatchMetrics do
                 value: 10.0,
               },
               {
-                dimensions: [
-                  {name: "appCluster", value: "1"},
-                  {name: "type", value: "foo"}],
+                metric_name: "Utilization",
+                dimensions: [{name: "Tag", value: "sidekiq-low"},
+                             {name: "appCluster", value: "1"},
+                             {name: "type", value: "foo"}],
+                timestamp: now,
+                unit: "Percent",
+                value: 10.0,
               },
               {
                 metric_name: "QueueSize",


### PR DESCRIPTION
Each Sidekiq process includes a tag attribute. This is by default the name of
the folder Sidekiq is running in, but can be configured in `sidekiq.yml`
by setting `tag: cluster-one` globally. This can be useful to identify groups of Sidekiq Processes if you have multiple
Sidekiq configurations in the same Sidekiq Cluster (eg, autoscaling groups subscribing to different queues)
and you want to identify them separately in Cloudwatch metrics. We're using this at Buildkite for autoscaling based on the Sidekiq utilization of workers in an Autoscaling Group. 

This change creates a new metric for each Sidekiq process with the `Tag` dimension. I attempted to add `Tag` as a new dimension to the existing metric but Cloudwatch "treats each unique combination of dimensions as a separate metric, even if the metrics have the same metric name" [1]. This wouldn't be backwards compatible and I wasn't able to group and filter the metrics with multiple dimensions in Cloudwatch and EC2 autoscaling. Currently this is only implemented for the Utilization metric.

Adding another metric per Sidekiq process might not be useful for those not consuming this feature, but I wanted to pitch this change without the option first so it was clear what I was trying to achieve here.

I also needed to modify the tests to support more than 20 metrics being emitted, as previously only a single batch of metrics was being emitted in a few of the test cases.

[1] [https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#Dimension](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#Dimension)