### PR TITLE
Add support for Sidekiq 6.5.0

### DIFF
--- a/lib/sidekiq/cloudwatchmetrics.rb
+++ b/lib/sidekiq/cloudwatchmetrics.rb
@@ -13,7 +13,7 @@ module Sidekiq::CloudWatchMetrics
     Sidekiq.configure_server do |config|
       publisher = Publisher.new(**kwargs)
 
-      if Sidekiq.options[:lifecycle_events].has_key?(:leader)
+      if Sidekiq.ent?
         # Only publish metrics on the leader if we have a leader (sidekiq-ent)
         config.on(:leader) do
           publisher.start

--- a/lib/sidekiq/cloudwatchmetrics.rb
+++ b/lib/sidekiq/cloudwatchmetrics.rb
@@ -2,11 +2,13 @@
 
 require "sidekiq"
 require "sidekiq/api"
-require "sidekiq/util"
 
 require "aws-sdk-cloudwatch"
 
 module Sidekiq::CloudWatchMetrics
+  SIDEKIQ_GTE_6_5_0 = Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new('6.5.0')
+  SIDEKIQ_GTE_6_5_0 ? (require "sidekiq/component") : (require "sidekiq/util")
+
   def self.enable!(**kwargs)
     Sidekiq.configure_server do |config|
       publisher = Publisher.new(**kwargs)
@@ -34,7 +36,7 @@ module Sidekiq::CloudWatchMetrics
   end
 
   class Publisher
-    include Sidekiq::Util
+    SIDEKIQ_GTE_6_5_0 ? (include Sidekiq::Component) : (include Sidekiq::Util)
 
     INTERVAL = 60 # seconds
 

--- a/lib/sidekiq/cloudwatchmetrics.rb
+++ b/lib/sidekiq/cloudwatchmetrics.rb
@@ -41,6 +41,7 @@ module Sidekiq::CloudWatchMetrics
     INTERVAL = 60 # seconds
 
     def initialize(client: Aws::CloudWatch::Client.new, namespace: "Sidekiq", additional_dimensions: {})
+      @config = Sidekiq
       @client = client
       @namespace = namespace
       @additional_dimensions = additional_dimensions.map { |k, v| {name: k.to_s, value: v.to_s} }

--- a/spec/sidekiq/cloudwatchmetrics_spec.rb
+++ b/spec/sidekiq/cloudwatchmetrics_spec.rb
@@ -2,11 +2,14 @@ require "spec_helper"
 
 RSpec.describe Sidekiq::CloudWatchMetrics do
   describe ".enable!" do
+    let(:options_deprecated) { Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new('6.5.0') }
+    let(:config) { options_deprecated ? Sidekiq : Sidekiq.options }
+
     # Sidekiq.options does a Sidekiq::DEFAULTS.dup which retains the same values, so
     # Sidekiq.options[:lifecycle_events] IS Sidekiq::DEFAULTS[:lifecycle_events] and
     # is mutable, so Sidekiq.options = nil will again Sidekiq::DEFAULTS.dup and get
     # the same Sidekiq::DEFAULTS[:lifecycle_events]. So we have to manually clear it.
-    before { Sidekiq.options[:lifecycle_events].each_value(&:clear) }
+    before { config[:lifecycle_events].each_value(&:clear) }
 
     context "in a sidekiq server" do
       before { allow(Sidekiq).to receive(:server?).and_return(true) }
@@ -18,9 +21,9 @@ RSpec.describe Sidekiq::CloudWatchMetrics do
         Sidekiq::CloudWatchMetrics.enable!
 
         # Look, this is hard.
-        expect(Sidekiq.options[:lifecycle_events][:startup]).not_to be_empty
-        expect(Sidekiq.options[:lifecycle_events][:quiet]).not_to be_empty
-        expect(Sidekiq.options[:lifecycle_events][:shutdown]).not_to be_empty
+        expect(config[:lifecycle_events][:startup]).not_to be_empty
+        expect(config[:lifecycle_events][:quiet]).not_to be_empty
+        expect(config[:lifecycle_events][:shutdown]).not_to be_empty
       end
     end
 
@@ -32,9 +35,9 @@ RSpec.describe Sidekiq::CloudWatchMetrics do
 
         Sidekiq::CloudWatchMetrics.enable!
 
-        expect(Sidekiq.options[:lifecycle_events][:startup]).to be_empty
-        expect(Sidekiq.options[:lifecycle_events][:quiet]).to be_empty
-        expect(Sidekiq.options[:lifecycle_events][:shutdown]).to be_empty
+        expect(config[:lifecycle_events][:startup]).to be_empty
+        expect(config[:lifecycle_events][:quiet]).to be_empty
+        expect(config[:lifecycle_events][:shutdown]).to be_empty
       end
     end
   end


### PR DESCRIPTION
Replace deprecated `Sidekiq.options`

Sidekiq 6.5.0 deprecated the `options` method on the `Sidekiq` class.
This change replaces the check for `leader` from `options` with a check for Sidekiq Enterprise.

The specs previously checked `lifecycle_events` using `options`.
To allow for backwards compatibility, the Sidekiq version is checked to use the appropriate method to access `lifecycle_events`.

Replace Sidekiq::Util with Sidekiq::Component

Previously the private `sidekiq/util` was being directly used in the gem to access the logger and safe_thread methods from Sidekiq.
In Sidekiq 6.5.0 `sidekiq/util` was removed and the methods were moved to `component`.

To prevent a breaking change, this change checks the Sidekiq version an includes the appropriate module.