### PR TITLE
Compatibility with Sidekiq >= 6.5.0

### DIFF
--- a/lib/sidekiq/cloudwatchmetrics.rb
+++ b/lib/sidekiq/cloudwatchmetrics.rb
@@ -2,7 +2,6 @@
 
 require "sidekiq"
 require "sidekiq/api"
-require "sidekiq/util"
 
 require "aws-sdk-cloudwatch"
 
@@ -34,7 +33,14 @@ module Sidekiq::CloudWatchMetrics
   end
 
   class Publisher
-    include Sidekiq::Util
+    if Sidekiq::VERSION >= Gem::Version.new('6.5.0')
+      def logger
+        Sidekiq.logger
+      end
+    else
+      require 'sidekiq/util'
+      include Sidekiq::Util
+    end
 
     INTERVAL = 60 # seconds
 


### PR DESCRIPTION
Sidekiq removed the `Sidekiq::Util` module in https://github.com/mperham/sidekiq/commit/67daa7a408b214d593100f782271ed108686c147 (released in 6.5.0), I'm suggesting to use directly `Sidekiq.logger` instead (which actually should already be available in previous versions)