### PR TITLE
Add support for Sidekiq 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches: [ main ]
-  pull_request: 
+  pull_request:
     branches: [ main ]
   workflow_dispatch: ~
 
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version: ['2.6', '2.7', '3.0', '3.1']
-        bundle-gemfile: ['Gemfile', 'Gemfile.sidekiq-5', 'Gemfile.sidekiq-6', 'Gemfile.sidekiq-6-0']
+        bundle-gemfile: ['Gemfile', 'Gemfile.sidekiq-5', 'Gemfile.sidekiq-6', 'Gemfile.sidekiq-6-0', 'Gemfile.sidekiq-7']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ jobs:
       matrix:
         ruby-version: ['2.6', '2.7', '3.0', '3.1']
         bundle-gemfile: ['Gemfile', 'Gemfile.sidekiq-5', 'Gemfile.sidekiq-6', 'Gemfile.sidekiq-6-0', 'Gemfile.sidekiq-7']
+        exclude:
+          # Sidekiq 7+ is ruby 2.7+ only
+          - ruby-version: 2.6
+            bundle-gemfile: Gemfile.sidekiq-7
 
     steps:
     - uses: actions/checkout@v2

--- a/Gemfile.sidekiq-7
+++ b/Gemfile.sidekiq-7
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+# Specify your gem's dependencies in sidekiq-cloudwatch.gemspec
+gemspec
+
+gem "sidekiq", "~> 7.0"

--- a/sidekiq-cloudwatchmetrics.gemspec
+++ b/sidekiq-cloudwatchmetrics.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.4"
 
-  spec.add_runtime_dependency "sidekiq", ">= 5.0", "< 7.0"
+  spec.add_runtime_dependency "sidekiq", ">= 5.0", "< 8.0"
   spec.add_runtime_dependency "aws-sdk-cloudwatch", "~> 1.6"
 
   spec.add_development_dependency "bundler", "~> 2.2"


### PR DESCRIPTION
I've started using this gem, but my company is already using Sidekiq 7, and this version not currently supported in the gemspec.

The only change required to make the gem compatible with Sidekiq 7 is to change `Sidekiq.options` to `Sidekiq::Config.new`; this only affects the tests.

Run test locally by doing:

```bash
BUNDLE_GEMFILE=Gemfile.sidekiq-7 bundle install
BUNDLE_GEMFILE=Gemfile.sidekiq-7 bundle exec rake spec
```

I've tested this version in production and can confirm it works.

Feel free to request any changes or take over the PR :)