### PR TITLE
Simplify specs

### DIFF
--- a/spec/sidekiq/cloudwatchmetrics_spec.rb
+++ b/spec/sidekiq/cloudwatchmetrics_spec.rb
@@ -54,79 +54,93 @@ RSpec.describe Sidekiq::CloudWatchMetrics do
 
     subject(:publisher) { Sidekiq::CloudWatchMetrics::Publisher.new(client: client) }
 
-    RSpec.shared_examples 'publishing sidekiq metrics to cloudwatch' do |options = {}|
-      it "publishes sidekiq metrics to cloudwatch under the #{options.fetch(:expected_namespace)} namespace" do
+    describe "#publish" do
+      let(:stats) do
+        instance_double(Sidekiq::Stats,
+          processed: 123,
+          failed: 456,
+          enqueued: 6,
+          scheduled_size: 1,
+          retry_size: 2,
+          dead_size: 3,
+          queues: queues.transform_values(&:size),
+          workers_size: 10,
+          processes_size: 5,
+          default_queue_latency: 1.23,
+        )
+      end
+      let(:processes) do
+        [
+          Sidekiq::Process.new("busy" => 5, "concurrency" => 10, "hostname" => "foo"),
+          Sidekiq::Process.new("busy" => 2, "concurrency" => 20, "hostname" => "bar"),
+        ]
+      end
+      let(:queues) do
+        {
+          "foo" => double(size: 1, latency: 1.23),
+          "bar" => double(size: 2, latency: 1.23),
+        }
+      end
+
+      before do
+        allow(Sidekiq::Stats).to receive(:new).and_return(stats)
+        allow(Sidekiq::ProcessSet).to receive(:new).and_return(processes)
+        allow(Sidekiq::Queue).to receive(:new) { |name| queues.fetch(name) }
+      end
+
+      it "publishes sidekiq metrics to cloudwatch" do
         Timecop.freeze(now = Time.now) do
-          stats = instance_double(Sidekiq::Stats,
-            processed: 123,
-            failed: 456,
-            enqueued: 6,
-            scheduled_size: 1,
-            retry_size: 2,
-            dead_size: 3,
-            queues: {"foo" => 1, "bar" => 2, "baz" => 3},
-            workers_size: 10,
-            processes_size: 5,
-            default_queue_latency: 1.23,
-          )
-          allow(Sidekiq::Stats).to receive(:new).and_return(stats)
-          processes = [
-            Sidekiq::Process.new("busy" => 5, "concurrency" => 10, "hostname" => "foo", "tag" => "sidekiq-high"),
-            Sidekiq::Process.new("busy" => 2, "concurrency" => 20, "hostname" => "bar", "tag" => "sidekiq-low"),
-          ]
-          allow(Sidekiq::ProcessSet).to receive(:new).and_return(processes)
-          allow(Sidekiq::Queue).to receive(:new).with(/foo|bar|baz/).and_return(double(latency: 1.23))
+          publisher.publish
 
-
-          expect(client).to receive(:put_metric_data).ordered.with(
-            namespace: options.fetch(:expected_namespace),
+          expect(client).to have_received(:put_metric_data).with(
+            namespace: "Sidekiq",
             metric_data: contain_exactly(
               {
                 metric_name: "ProcessedJobs",
                 timestamp: now,
-                value: stats.processed,
+                value: 123,
                 unit: "Count",
               },
               {
                 metric_name: "FailedJobs",
                 timestamp: now,
-                value: stats.failed,
+                value: 456,
                 unit: "Count",
               },
               {
                 metric_name: "EnqueuedJobs",
                 timestamp: now,
-                value: stats.enqueued,
+                value: 6,
                 unit: "Count",
               },
               {
                 metric_name: "ScheduledJobs",
                 timestamp: now,
-                value: stats.scheduled_size,
+                value: 1,
                 unit: "Count",
               },
               {
                 metric_name: "RetryJobs",
                 timestamp: now,
-                value: stats.retry_size,
+                value: 2,
                 unit: "Count",
               },
               {
                 metric_name: "DeadJobs",
                 timestamp: now,
-                value: stats.dead_size,
+                value: 3,
                 unit: "Count",
               },
               {
                 metric_name: "Workers",
                 timestamp: now,
-                value: stats.workers_size,
+                value: 10,
                 unit: "Count",
               },
               {
                 metric_name: "Processes",
                 timestamp: now,
-                value: stats.processes_size,
+                value: 5,
                 unit: "Count",
               },
               {
@@ -144,19 +158,26 @@ RSpec.describe Sidekiq::CloudWatchMetrics do
               {
                 metric_name: "DefaultQueueLatency",
                 timestamp: now,
-                value: stats.default_queue_latency,
+                value: 1.23,
                 unit: "Seconds",
               },
               {
                 metric_name: "Utilization",
-                dimensions: [{name: "Hostname", value: "foo"}],
+                dimensions: [{name: "Tag", value: nil}],
                 timestamp: now,
                 unit: "Percent",
                 value: 50.0,
               },
               {
                 metric_name: "Utilization",
-                dimensions: [{name: "Tag", value: "sidekiq-high"}],
+                dimensions: [{name: "Tag", value: nil}],
+                timestamp: now,
+                unit: "Percent",
+                value: 10.0,
+              },
+              {
+                metric_name: "Utilization",
+                dimensions: [{name: "Hostname", value: "foo"}],
                 timestamp: now,
                 unit: "Percent",
                 value: 50.0,
@@ -169,17 +190,10 @@ RSpec.describe Sidekiq::CloudWatchMetrics do
                 value: 10.0,
               },
               {
-                metric_name: "Utilization",
-                dimensions: [{name: "Tag", value: "sidekiq-low"}],
-                timestamp: now,
-                unit: "Percent",
-                value: 10.0,
-              },
-              {
                 metric_name: "QueueSize",
                 dimensions: [{name: "QueueName", value: "foo"}],
                 timestamp: now,
-                value: stats.queues["foo"],
+                value: 1,
                 unit: "Count",
               },
               {
@@ -193,7 +207,7 @@ RSpec.describe Sidekiq::CloudWatchMetrics do
                 metric_name: "QueueSize",
                 dimensions: [{name: "QueueName", value: "bar"}],
                 timestamp: now,
-                value: stats.queues["bar"],
+                value: 2,
                 unit: "Count",
               },
               {
@@ -203,282 +217,52 @@ RSpec.describe Sidekiq::CloudWatchMetrics do
                 value: 1.23,
                 unit: "Seconds",
               },
-              {
-                metric_name: "QueueSize",
-                dimensions: [{name: "QueueName", value: "baz"}],
-                timestamp: now,
-                value: stats.queues["baz"],
-                unit: "Count",
-              },
             ),
           )
-
-          expect(client).to receive(:put_metric_data).ordered.with(
-            namespace: options.fetch(:expected_namespace),
-            metric_data: contain_exactly(
-              {
-                metric_name: "QueueLatency",
-                dimensions: [{name: "QueueName", value: "baz"}],
-                timestamp: now,
-                value: 1.23,
-                unit: "Seconds",
-              },
-            ),
-          )
-
-          publisher.publish
-        end
-      end
-    end
-
-    describe "#publish" do
-      include_examples 'publishing sidekiq metrics to cloudwatch', expected_namespace: 'Sidekiq'
-
-      context 'with a custom namespace' do
-        subject(:publisher) { Sidekiq::CloudWatchMetrics::Publisher.new(client: client, namespace: 'Sidekiq-Test') }
-
-        include_examples 'publishing sidekiq metrics to cloudwatch', expected_namespace: 'Sidekiq-Test'
-      end
-
-      it "publishes custom dimensions" do
-        Timecop.freeze(now = Time.now) do
-          stats = instance_double(Sidekiq::Stats,
-            processed: 123,
-            failed: 456,
-            enqueued: 6,
-            scheduled_size: 1,
-            retry_size: 2,
-            dead_size: 3,
-            queues: {"foo" => 1, "bar" => 2, "baz" => 3},
-            workers_size: 10,
-            processes_size: 5,
-            default_queue_latency: 1.23,
-          )
-          allow(Sidekiq::Stats).to receive(:new).and_return(stats)
-          processes = [
-            Sidekiq::Process.new("busy" => 5, "concurrency" => 10, "hostname" => "foo", "tag" => "sidekiq-high"),
-            Sidekiq::Process.new("busy" => 2, "concurrency" => 20, "hostname" => "bar", "tag" => "sidekiq-low"),
-          ]
-          allow(Sidekiq::ProcessSet).to receive(:new).and_return(processes)
-          allow(Sidekiq::Queue).to receive(:new).with(/foo|bar|baz/).and_return(double(latency: 1.23))
-
-          publisher_with_custom_dimensions =
-            Sidekiq::CloudWatchMetrics::Publisher.new(client: client, additional_dimensions: {appCluster: 1, type: "foo"})
-
-          expect(client).to receive(:put_metric_data).ordered.with(
-            namespace: "Sidekiq",
-            metric_data: contain_exactly(
-              {
-                metric_name: "ProcessedJobs",
-                timestamp: now,
-                value: stats.processed,
-                unit: "Count",
-                dimensions: [{name: "appCluster", value: "1"},
-                             {name: "type", value: "foo"}],
-              },
-              {
-                metric_name: "FailedJobs",
-                timestamp: now,
-                value: stats.failed,
-                unit: "Count",
-                dimensions: [{name: "appCluster", value: "1"},
-                             {name: "type", value: "foo"}],
-              },
-              {
-                metric_name: "EnqueuedJobs",
-                timestamp: now,
-                value: stats.enqueued,
-                unit: "Count",
-                dimensions: [{name: "appCluster", value: "1"},
-                             {name: "type", value: "foo"}],
-              },
-              {
-                metric_name: "ScheduledJobs",
-                timestamp: now,
-                value: stats.scheduled_size,
-                unit: "Count",
-                dimensions: [{name: "appCluster", value: "1"},
-                             {name: "type", value: "foo"}],
-              },
-              {
-                metric_name: "RetryJobs",
-                timestamp: now,
-                value: stats.retry_size,
-                unit: "Count",
-                dimensions: [{name: "appCluster", value: "1"},
-                             {name: "type", value: "foo"}],
-              },
-              {
-                metric_name: "DeadJobs",
-                timestamp: now,
-                value: stats.dead_size,
-                unit: "Count",
-                dimensions: [{name: "appCluster", value: "1"},
-                             {name: "type", value: "foo"}],
-              },
-              {
-                metric_name: "Workers",
-                timestamp: now,
-                value: stats.workers_size,
-                unit: "Count",
-                dimensions: [{name: "appCluster", value: "1"},
-                             {name: "type", value: "foo"}],
-              },
-              {
-                metric_name: "Processes",
-                timestamp: now,
-                value: stats.processes_size,
-                unit: "Count",
-                dimensions: [{name: "appCluster", value: "1"},
-                             {name: "type", value: "foo"}],
-              },
-              {
-                metric_name: "Capacity",
-                timestamp: now,
-                value: 30,
-                unit: "Count",
-                dimensions: [{name: "appCluster", value: "1"},
-                             {name: "type", value: "foo"}],
-              },
-              {
-                metric_name: "Utilization",
-                timestamp: now,
-                value: 30.0,
-                unit: "Percent",
-                dimensions: [{name: "appCluster", value: "1"},
-                             {name: "type", value: "foo"}],
-              },
-              {
-                metric_name: "DefaultQueueLatency",
-                timestamp: now,
-                value: stats.default_queue_latency,
-                unit: "Seconds",
-                dimensions: [{name: "appCluster", value: "1"},
-                             {name: "type", value: "foo"}],
-              },
-              {
-                metric_name: "Utilization",
-                dimensions: [{name: "Hostname", value: "foo"},
-                             {name: "appCluster", value: "1"},
-                             {name: "type", value: "foo"}],
-                timestamp: now,
-                unit: "Percent",
-                value: 50.0,
-              },
-              {
-                metric_name: "Utilization",
-                dimensions: [{name: "Tag", value: "sidekiq-high"},
-                             {name: "appCluster", value: "1"},
-                             {name: "type", value: "foo"}],
-                timestamp: now,
-                unit: "Percent",
-                value: 50.0,
-              },
-              {
-                metric_name: "Utilization",
-                dimensions: [{name: "Hostname", value: "bar"},
-                             {name: "appCluster", value: "1"},
-                             {name: "type", value: "foo"}],
-                timestamp: now,
-                unit: "Percent",
-                value: 10.0,
-              },
-              {
-                metric_name: "Utilization",
-                dimensions: [{name: "Tag", value: "sidekiq-low"},
-                             {name: "appCluster", value: "1"},
-                             {name: "type", value: "foo"}],
-                timestamp: now,
-                unit: "Percent",
-                value: 10.0,
-              },
-              {
-                metric_name: "QueueSize",
-                dimensions: [{name: "QueueName", value: "foo"},
-                             {name: "appCluster", value: "1"},
-                             {name: "type", value: "foo"}],
-                timestamp: now,
-                value: stats.queues["foo"],
-                unit: "Count",
-              },
-              {
-                metric_name: "QueueLatency",
-                dimensions: [{name: "QueueName", value: "foo"},
-                             {name: "appCluster", value: "1"},
-                             {name: "type", value: "foo"}],
-                timestamp: now,
-                value: 1.23,
-                unit: "Seconds",
-              },
-              {
-                metric_name: "QueueSize",
-                dimensions: [{name: "QueueName", value: "bar"},
-                             {name: "appCluster", value: "1"},
-                             {name: "type", value: "foo"}],
-                timestamp: now,
-                value: stats.queues["bar"],
-                unit: "Count",
-              },
-              {
-                metric_name: "QueueLatency",
-                dimensions: [{name: "QueueName", value: "bar"},
-                             {name: "appCluster", value: "1"},
-                             {name: "type", value: "foo"}],
-                timestamp: now,
-                value: 1.23,
-                unit: "Seconds",
-              },
-              {
-                metric_name: "QueueSize",
-                dimensions: [{name: "QueueName", value: "baz"},
-                             {name: "appCluster", value: "1"},
-                             {name: "type", value: "foo"}],
-                timestamp: now,
-                value: stats.queues["baz"],
-                unit: "Count",
-              }
-            ),
-          )
-
-          expect(client).to receive(:put_metric_data).ordered.with(
-            namespace: "Sidekiq",
-            metric_data: contain_exactly(
-              {
-                metric_name: "QueueLatency",
-                dimensions: [{name: "QueueName", value: "baz"},
-                             {name: "appCluster", value: "1"},
-                             {name: "type", value: "foo"}],
-                timestamp: now,
-                value: 1.23,
-                unit: "Seconds",
-              }
-            ),
-          )
-
-          publisher_with_custom_dimensions.publish
         end
       end
 
-      it "publishes sidekiq metrics to cloudwatch for lots of queues in batches of 20" do
-        Timecop.freeze(now = Time.now) do
-          stats = instance_double(Sidekiq::Stats,
-            processed: 123,
-            failed: 456,
-            enqueued: 6,
-            scheduled_size: 1,
-            retry_size: 2,
-            dead_size: 3,
-            queues: 30.times.each_with_object({}) { |i, hash| hash["queue#{i}"] = i },
-            workers_size: 10,
-            processes_size: 5,
-            default_queue_latency: 1.23,
-          )
-          allow(Sidekiq::Stats).to receive(:new).and_return(stats)
-          allow(Sidekiq::Queue).to receive(:new).with(/queue\d/).and_return(double(latency: 1.23))
+      context "with lots of queues" do
+        let(:queues) { 10.times.each_with_object({}) { |i, hash| hash["queue#{i}"] = double(size: 1, latency: 1.23) } }
 
-          publisher.publish
+        it "publishes sidekiq metrics to cloudwatch in batches of 20" do
+          Timecop.freeze(now = Time.now) do
+            publisher.publish
 
-          expect(client).to have_received(:put_metric_data).exactly(4).times
+            expect(client).to have_received(:put_metric_data) { |metrics|
+              expect(metrics[:metric_data].size).to be <= 20
+            }.at_least(:twice)
+          end
+        end
+      end
+
+      context "with custom dimensions" do
+        subject(:publisher) { Sidekiq::CloudWatchMetrics::Publisher.new(client: client, additional_dimensions: {appCluster: 1, type: "foo"}) }
+
+        it "publishes metrics with custom dimensions" do
+          Timecop.freeze(now = Time.now) do
+            publisher.publish
+
+            expect(client).to have_received(:put_metric_data) { |metrics|
+              metrics[:metric_data].each do |metric|
+                expect(metric[:dimensions]).to include({name: "appCluster", value: "1"}, {name: "type", value: "foo"})
+              end
+            }.at_least(:once)
+          end
+        end
+      end
+
+      context "with a custom namespace" do
+        subject(:publisher) { Sidekiq::CloudWatchMetrics::Publisher.new(client: client, namespace: "Sidekiq-Test") }
+
+        it "publishes metrics with the specified namespace" do
+          Timecop.freeze(now = Time.now) do
+            publisher.publish
+
+            expect(client).to have_received(:put_metric_data) { |metrics|
+              expect(metrics[:namespace]).to eql("Sidekiq-Test")
+            }.at_least(:once)
+          end
         end
       end
     end


### PR DESCRIPTION
The specs are a bit unruly. This removes the shared examples, makes it easier to change things to test them, and removes some duplication.