### PR TITLE
Fix tag dimension

### DIFF
--- a/lib/sidekiq/cloudwatchmetrics.rb
+++ b/lib/sidekiq/cloudwatchmetrics.rb
@@ -159,17 +159,15 @@ module Sidekiq::CloudWatchMetrics
       ]
 
       processes.each do |process|
-        metrics << {
-          metric_name: "Utilization",
-          dimensions: [{name: "Hostname", value: process["hostname"]}],
-          timestamp: now,
-          value: process["busy"] / process["concurrency"].to_f * 100.0,
-          unit: "Percent",
-        }
+        process_dimensions = [{name: "Hostname", value: process["hostname"]}]
+
+        if process["tag"]
+          process_dimensions << {name: "Tag", value: process["tag"]}
+        end
 
         metrics << {
           metric_name: "Utilization",
-          dimensions: [{name: "Tag", value: process["tag"]}],
+          dimensions: process_dimensions,
           timestamp: now,
           value: process["busy"] / process["concurrency"].to_f * 100.0,
           unit: "Percent",


### PR DESCRIPTION
Simplifying the specs made me review the tag dimension. Publishing utilization with the same tag is going to lead to incorrect metrics. They should be added to the existing per-process utilization metrics, not added separately.

It also doesn't seem useful to submit a nil value.