### PR TITLE
Use 'logger.debug' instead of 'logger.info' for quieter logs by default

### DIFF
--- a/lib/sidekiq/cloudwatchmetrics.rb
+++ b/lib/sidekiq/cloudwatchmetrics.rb
@@ -56,7 +56,7 @@ module Sidekiq::CloudWatchMetrics
     end
 
     def start
-      logger.info { "Starting Sidekiq CloudWatch Metrics Publisher" }
+      logger.debug { "Starting Sidekiq CloudWatch Metrics Publisher" }
 
       @done = false
       @thread = safe_thread("cloudwatch metrics publisher", &method(:run))
@@ -67,13 +67,13 @@ module Sidekiq::CloudWatchMetrics
     end
 
     def run
-      logger.info { "Started Sidekiq CloudWatch Metrics Publisher" }
+      logger.debug { "Started Sidekiq CloudWatch Metrics Publisher" }
 
       # Publish stats every INTERVAL seconds, sleeping as required between runs
       now = Time.now.to_f
       tick = now
       until @stop
-        logger.info { "Publishing Sidekiq CloudWatch Metrics" }
+        logger.debug { "Publishing Sidekiq CloudWatch Metrics" }
         publish
 
         now = Time.now.to_f
@@ -81,7 +81,7 @@ module Sidekiq::CloudWatchMetrics
         sleep(tick - now) if tick > now
       end
 
-      logger.info { "Stopped Sidekiq CloudWatch Metrics Publisher" }
+      logger.debug { "Stopped Sidekiq CloudWatch Metrics Publisher" }
     end
 
     def publish
@@ -257,12 +257,12 @@ module Sidekiq::CloudWatchMetrics
     end
 
     def quiet
-      logger.info { "Quieting Sidekiq CloudWatch Metrics Publisher" }
+      logger.debug { "Quieting Sidekiq CloudWatch Metrics Publisher" }
       @stop = true
     end
 
     def stop
-      logger.info { "Stopping Sidekiq CloudWatch Metrics Publisher" }
+      logger.debug { "Stopping Sidekiq CloudWatch Metrics Publisher" }
       @stop = true
       @thread.wakeup
       @thread.join


### PR DESCRIPTION
Related to #37, using `logger.debug` instead of a new configuration flag 