### PR TITLE
 empty string in ruby is not falsy, adding empty? check to only add tag dimension if it is present

### DIFF
--- a/lib/sidekiq/cloudwatchmetrics.rb
+++ b/lib/sidekiq/cloudwatchmetrics.rb
@@ -189,7 +189,7 @@ module Sidekiq::CloudWatchMetrics
           unless process_utilization.nan?
             process_dimensions = [{name: "Hostname", value: process["hostname"]}]
 
-            unless process['tag'].empty?
+            unless process["tag"].empty?
               process_dimensions << {name: "Tag", value: process["tag"]}
             end
 

--- a/lib/sidekiq/cloudwatchmetrics.rb
+++ b/lib/sidekiq/cloudwatchmetrics.rb
@@ -189,7 +189,7 @@ module Sidekiq::CloudWatchMetrics
           unless process_utilization.nan?
             process_dimensions = [{name: "Hostname", value: process["hostname"]}]
 
-            if process["tag"]
+            unless process['tag'].empty?
               process_dimensions << {name: "Tag", value: process["tag"]}
             end
 


### PR DESCRIPTION
This PR is opened against [this issue](https://github.com/sj26/sidekiq-cloudwatchmetrics/issues/43)

Where the check `if process["tag"]` is returning true in case of empty string, which caused the issue for aws-sdk-cloudwatch library
<img width="840" alt="image" src="https://github.com/sj26/sidekiq-cloudwatchmetrics/assets/21343715/e904beee-bba8-4a16-ab89-61a720542724">
