### PR TITLE
Extract collector for metrics extensibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+## [2.6.1] - 2023-12-26
+
+- Add `collector` option.
+- Deprecate `process_metrics` and `additional_dimensions`.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,26 @@ The default namespace for metrics is "Sidekiq". You can configure this with the 
 Sidekiq::CloudWatchMetrics.enable!(client: Aws::CloudWatch::Client.new, namespace: "Sidekiq-Staging")
 ```
 
+You can also extend the metrics that are collected:
+
+```ruby
+class CustomCollector < Sidekiq::CloudWatchMetrics::Collector
+  def collect
+    metrics = super
+
+    metrics << {
+      metric_name: 'MaxQueueLatency',
+      timestamp: Time.now,
+      value: Sidekiq::Queue.all.map(&:latency).max,
+      unit: 'Seconds'
+    }
+
+    metrics
+  end
+end
+
+Sidekiq::CloudWatchMetrics.enable!(collector: CustomCollector.new)
+```
 
 ## Development
 

--- a/lib/sidekiq/cloud_watch_metrics/collector.rb
+++ b/lib/sidekiq/cloud_watch_metrics/collector.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "sidekiq/api"
+
 module Sidekiq::CloudWatchMetrics
   class Collector
     def initialize(process_metrics: true, additional_dimensions: {})

--- a/lib/sidekiq/cloud_watch_metrics/collector.rb
+++ b/lib/sidekiq/cloud_watch_metrics/collector.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+module Sidekiq::CloudWatchMetrics
+  class Collector
+    def initialize(process_metrics: true, additional_dimensions: {})
+      @process_metrics = process_metrics
+      @additional_dimensions = additional_dimensions.map { |k, v| {name: k.to_s, value: v.to_s} }
+    end
+
+    def collect
+      now = Time.now
+      stats = Sidekiq::Stats.new
+      processes = Sidekiq::ProcessSet.new.to_enum(:each).to_a
+      queues = stats.queues
+
+      metrics = [
+        {
+          metric_name: "ProcessedJobs",
+          timestamp: now,
+          value: stats.processed,
+          unit: "Count",
+        },
+        {
+          metric_name: "FailedJobs",
+          timestamp: now,
+          value: stats.failed,
+          unit: "Count",
+        },
+        {
+          metric_name: "EnqueuedJobs",
+          timestamp: now,
+          value: stats.enqueued,
+          unit: "Count",
+        },
+        {
+          metric_name: "ScheduledJobs",
+          timestamp: now,
+          value: stats.scheduled_size,
+          unit: "Count",
+        },
+        {
+          metric_name: "RetryJobs",
+          timestamp: now,
+          value: stats.retry_size,
+          unit: "Count",
+        },
+        {
+          metric_name: "DeadJobs",
+          timestamp: now,
+          value: stats.dead_size,
+          unit: "Count",
+        },
+        {
+          metric_name: "Workers",
+          timestamp: now,
+          value: stats.workers_size,
+          unit: "Count",
+        },
+        {
+          metric_name: "Processes",
+          timestamp: now,
+          value: stats.processes_size,
+          unit: "Count",
+        },
+        {
+          metric_name: "DefaultQueueLatency",
+          timestamp: now,
+          value: stats.default_queue_latency,
+          unit: "Seconds",
+        },
+        {
+          metric_name: "Capacity",
+          timestamp: now,
+          value: calculate_capacity(processes),
+          unit: "Count",
+        },
+      ]
+
+      utilization = calculate_utilization(processes) * 100.0
+
+      unless utilization.nan?
+        metrics << {
+          metric_name: "Utilization",
+          timestamp: now,
+          value: utilization,
+          unit: "Percent",
+        }
+      end
+
+      processes.group_by do |process|
+        process["tag"]
+      end.each do |(tag, tag_processes)|
+        next if tag.nil?
+
+        tag_utilization = calculate_utilization(tag_processes) * 100.0
+
+        unless tag_utilization.nan?
+          metrics << {
+            metric_name: "Utilization",
+            dimensions: [{name: "Tag", value: tag}],
+            timestamp: now,
+            value: tag_utilization,
+            unit: "Percent",
+          }
+        end
+      end
+
+      if @process_metrics
+        processes.each do |process|
+          process_utilization = process["busy"] / process["concurrency"].to_f * 100.0
+
+          unless process_utilization.nan?
+            process_dimensions = [{name: "Hostname", value: process["hostname"]}]
+
+            if process["tag"]
+              process_dimensions << {name: "Tag", value: process["tag"]}
+            end
+
+            metrics << {
+              metric_name: "Utilization",
+              dimensions: process_dimensions,
+              timestamp: now,
+              value: process_utilization,
+              unit: "Percent",
+            }
+          end
+        end
+      end
+
+      queues.each do |(queue_name, queue_size)|
+        metrics << {
+          metric_name: "QueueSize",
+          dimensions: [{name: "QueueName", value: queue_name}],
+          timestamp: now,
+          value: queue_size,
+          unit: "Count",
+        }
+
+        queue_latency = Sidekiq::Queue.new(queue_name).latency
+
+        metrics << {
+          metric_name: "QueueLatency",
+          dimensions: [{name: "QueueName", value: queue_name}],
+          timestamp: now,
+          value: queue_latency,
+          unit: "Seconds",
+        }
+      end
+
+      unless @additional_dimensions.empty?
+        metrics = metrics.each do |metric|
+          metric[:dimensions] = (metric[:dimensions] || []) + @additional_dimensions
+        end
+      end
+
+      metrics
+    end
+
+    # Returns the total number of workers across all processes
+    private def calculate_capacity(processes)
+      processes.map do |process|
+        process["concurrency"]
+      end.sum
+    end
+
+    # Returns busy / concurrency averaged across processes (for scaling)
+    # Avoid considering processes not yet running any threads
+    private def calculate_utilization(processes)
+      process_utilizations = processes.map do |process|
+        process["busy"] / process["concurrency"].to_f
+      end.reject(&:nan?)
+
+      process_utilizations.sum / process_utilizations.size.to_f
+    end
+  end
+end

--- a/lib/sidekiq/cloud_watch_metrics/publisher.rb
+++ b/lib/sidekiq/cloud_watch_metrics/publisher.rb
@@ -29,6 +29,7 @@ module Sidekiq::CloudWatchMetrics
       @config = config
       @client = client
       @namespace = namespace
+
       if collector_kwargs.size > 0
         warn <<~TEXT
           Implicit collector arguments are deprecated.
@@ -76,8 +77,8 @@ module Sidekiq::CloudWatchMetrics
       metrics.each_slice(20) do |some_metrics|
         @client.put_metric_data(
           namespace: @namespace,
-          metric_data: some_metrics,
-          )
+          metric_data: some_metrics
+        )
       end
     end
 

--- a/lib/sidekiq/cloud_watch_metrics/publisher.rb
+++ b/lib/sidekiq/cloud_watch_metrics/publisher.rb
@@ -23,18 +23,21 @@ module Sidekiq::CloudWatchMetrics
                    client: Aws::CloudWatch::Client.new,
                    namespace: "Sidekiq",
                    collector: nil,
-                   process_metrics: true,
-                   additional_dimensions: {})
+                   **collector_kwargs)
       # Sidekiq 6.5+ requires @config, which defaults to the top-level
       # `Sidekiq` module, but can be overridden when running multiple Sidekiqs.
       @config = config
       @client = client
       @namespace = namespace
-      @collector = collector ||
-        Collector.new(
-          process_metrics: process_metrics,
-          additional_dimensions: additional_dimensions
-        )
+      if collector_kwargs.size > 0
+        warn <<~TEXT
+          Implicit collector arguments are deprecated.
+          Please instantiate a collector and pass it explicitly:
+          Sidekiq::CloudWatchMetrics.enable!(collector: CustomCollector.new)
+        TEXT
+      end
+
+      @collector = collector || Collector.new(**collector_kwargs)
     end
 
     def start

--- a/lib/sidekiq/cloud_watch_metrics/publisher.rb
+++ b/lib/sidekiq/cloud_watch_metrics/publisher.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "sidekiq"
+
+require "aws-sdk-cloudwatch"
+
+require "sidekiq/cloud_watch_metrics/collector"
+
+module Sidekiq::CloudWatchMetrics
+  class Publisher
+    begin
+      require "sidekiq/util"
+      include Sidekiq::Util
+    rescue LoadError
+      # Sidekiq 6.5 refactored to use Sidekiq::Component
+      require "sidekiq/component"
+      include Sidekiq::Component
+    end
+
+    INTERVAL = 60 # seconds
+
+    def initialize(config: Sidekiq,
+                   client: Aws::CloudWatch::Client.new,
+                   namespace: "Sidekiq",
+                   collector: nil,
+                   process_metrics: true,
+                   additional_dimensions: {})
+      # Sidekiq 6.5+ requires @config, which defaults to the top-level
+      # `Sidekiq` module, but can be overridden when running multiple Sidekiqs.
+      @config = config
+      @client = client
+      @namespace = namespace
+      @collector = collector ||
+        Collector.new(
+          process_metrics: process_metrics,
+          additional_dimensions: additional_dimensions
+        )
+    end
+
+    def start
+      logger.debug { "Starting Sidekiq CloudWatch Metrics Publisher" }
+
+      @done = false
+      @thread = safe_thread("cloudwatch metrics publisher", &method(:run))
+    end
+
+    def running?
+      !@thread.nil? && @thread.alive?
+    end
+
+    def run
+      logger.info { "Started Sidekiq CloudWatch Metrics Publisher" }
+
+      # Publish stats every INTERVAL seconds, sleeping as required between runs
+      now = Time.now.to_f
+      tick = now
+      until @stop
+        logger.debug { "Publishing Sidekiq CloudWatch Metrics" }
+        publish
+
+        now = Time.now.to_f
+        tick = [tick + INTERVAL, now].max
+        sleep(tick - now) if tick > now
+      end
+
+      logger.debug { "Stopped Sidekiq CloudWatch Metrics Publisher" }
+    end
+
+    def publish
+      metrics = @collector.collect
+
+      # We can only put 20 metrics at a time
+      metrics.each_slice(20) do |some_metrics|
+        @client.put_metric_data(
+          namespace: @namespace,
+          metric_data: some_metrics,
+          )
+      end
+    end
+
+    def quiet
+      logger.debug { "Quieting Sidekiq CloudWatch Metrics Publisher" }
+      @stop = true
+    end
+
+    def stop
+      logger.debug { "Stopping Sidekiq CloudWatch Metrics Publisher" }
+      @stop = true
+      @thread.wakeup
+      @thread.join
+    rescue ThreadError
+      # Don't raise if thread is already dead.
+      nil
+    end
+  end
+end

--- a/lib/sidekiq/cloudwatchmetrics.rb
+++ b/lib/sidekiq/cloudwatchmetrics.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
 
 require "sidekiq"
-require "sidekiq/api"
 
-require "aws-sdk-cloudwatch"
-
-require_relative 'cloud_watch_metrics/collector'
+require "sidekiq/cloud_watch_metrics/publisher"
 
 module Sidekiq::CloudWatchMetrics
   def self.enable!(**kwargs)
@@ -32,93 +29,6 @@ module Sidekiq::CloudWatchMetrics
       config.on(:shutdown) do
         publisher.stop if publisher.running?
       end
-    end
-  end
-
-  class Publisher
-    begin
-      require "sidekiq/util"
-      include Sidekiq::Util
-    rescue LoadError
-      # Sidekiq 6.5 refactored to use Sidekiq::Component
-      require "sidekiq/component"
-      include Sidekiq::Component
-    end
-
-    INTERVAL = 60 # seconds
-
-    def initialize(config: Sidekiq,
-                   client: Aws::CloudWatch::Client.new,
-                   namespace: "Sidekiq",
-                   collector: nil,
-                   process_metrics: true,
-                   additional_dimensions: {})
-      # Sidekiq 6.5+ requires @config, which defaults to the top-level
-      # `Sidekiq` module, but can be overridden when running multiple Sidekiqs.
-      @config = config
-      @client = client
-      @namespace = namespace
-      @collector = collector ||
-        Sidekiq::CloudWatchMetrics::Collector.new(
-          process_metrics: process_metrics,
-          additional_dimensions: additional_dimensions
-        )
-    end
-
-    def start
-      logger.debug { "Starting Sidekiq CloudWatch Metrics Publisher" }
-
-      @done = false
-      @thread = safe_thread("cloudwatch metrics publisher", &method(:run))
-    end
-
-    def running?
-      !@thread.nil? && @thread.alive?
-    end
-
-    def run
-      logger.info { "Started Sidekiq CloudWatch Metrics Publisher" }
-
-      # Publish stats every INTERVAL seconds, sleeping as required between runs
-      now = Time.now.to_f
-      tick = now
-      until @stop
-        logger.debug { "Publishing Sidekiq CloudWatch Metrics" }
-        publish
-
-        now = Time.now.to_f
-        tick = [tick + INTERVAL, now].max
-        sleep(tick - now) if tick > now
-      end
-
-      logger.debug { "Stopped Sidekiq CloudWatch Metrics Publisher" }
-    end
-
-    def publish
-      metrics = @collector.collect
-
-      # We can only put 20 metrics at a time
-      metrics.each_slice(20) do |some_metrics|
-        @client.put_metric_data(
-          namespace: @namespace,
-          metric_data: some_metrics,
-          )
-      end
-    end
-
-    def quiet
-      logger.debug { "Quieting Sidekiq CloudWatch Metrics Publisher" }
-      @stop = true
-    end
-
-    def stop
-      logger.debug { "Stopping Sidekiq CloudWatch Metrics Publisher" }
-      @stop = true
-      @thread.wakeup
-      @thread.join
-    rescue ThreadError
-      # Don't raise if thread is already dead.
-      nil
     end
   end
 end

--- a/lib/sidekiq/cloudwatchmetrics.rb
+++ b/lib/sidekiq/cloudwatchmetrics.rb
@@ -5,6 +5,8 @@ require "sidekiq/api"
 
 require "aws-sdk-cloudwatch"
 
+require_relative 'cloud_watch_metrics/collector'
+
 module Sidekiq::CloudWatchMetrics
   def self.enable!(**kwargs)
     Sidekiq.configure_server do |config|
@@ -45,14 +47,22 @@ module Sidekiq::CloudWatchMetrics
 
     INTERVAL = 60 # seconds
 
-    def initialize(config: Sidekiq, client: Aws::CloudWatch::Client.new, namespace: "Sidekiq", process_metrics: true, additional_dimensions: {})
+    def initialize(config: Sidekiq,
+                   client: Aws::CloudWatch::Client.new,
+                   namespace: "Sidekiq",
+                   collector: nil,
+                   process_metrics: true,
+                   additional_dimensions: {})
       # Sidekiq 6.5+ requires @config, which defaults to the top-level
       # `Sidekiq` module, but can be overridden when running multiple Sidekiqs.
       @config = config
       @client = client
       @namespace = namespace
-      @process_metrics = process_metrics
-      @additional_dimensions = additional_dimensions.map { |k, v| {name: k.to_s, value: v.to_s} }
+      @collector = collector ||
+        Sidekiq::CloudWatchMetrics::Collector.new(
+          process_metrics: process_metrics,
+          additional_dimensions: additional_dimensions
+        )
     end
 
     def start
@@ -85,7 +95,7 @@ module Sidekiq::CloudWatchMetrics
     end
 
     def publish
-      metrics = collect_metrics(now: Time.now)
+      metrics = @collector.collect
 
       # We can only put 20 metrics at a time
       metrics.each_slice(20) do |some_metrics|
@@ -94,171 +104,6 @@ module Sidekiq::CloudWatchMetrics
           metric_data: some_metrics,
           )
       end
-    end
-
-    private def collect_metrics(now:)
-      stats = Sidekiq::Stats.new
-      processes = Sidekiq::ProcessSet.new.to_enum(:each).to_a
-      queues = stats.queues
-
-      metrics = [
-        {
-          metric_name: "ProcessedJobs",
-          timestamp: now,
-          value: stats.processed,
-          unit: "Count",
-        },
-        {
-          metric_name: "FailedJobs",
-          timestamp: now,
-          value: stats.failed,
-          unit: "Count",
-        },
-        {
-          metric_name: "EnqueuedJobs",
-          timestamp: now,
-          value: stats.enqueued,
-          unit: "Count",
-        },
-        {
-          metric_name: "ScheduledJobs",
-          timestamp: now,
-          value: stats.scheduled_size,
-          unit: "Count",
-        },
-        {
-          metric_name: "RetryJobs",
-          timestamp: now,
-          value: stats.retry_size,
-          unit: "Count",
-        },
-        {
-          metric_name: "DeadJobs",
-          timestamp: now,
-          value: stats.dead_size,
-          unit: "Count",
-        },
-        {
-          metric_name: "Workers",
-          timestamp: now,
-          value: stats.workers_size,
-          unit: "Count",
-        },
-        {
-          metric_name: "Processes",
-          timestamp: now,
-          value: stats.processes_size,
-          unit: "Count",
-        },
-        {
-          metric_name: "DefaultQueueLatency",
-          timestamp: now,
-          value: stats.default_queue_latency,
-          unit: "Seconds",
-        },
-        {
-          metric_name: "Capacity",
-          timestamp: now,
-          value: calculate_capacity(processes),
-          unit: "Count",
-        },
-      ]
-
-      utilization = calculate_utilization(processes) * 100.0
-
-      unless utilization.nan?
-        metrics << {
-          metric_name: "Utilization",
-          timestamp: now,
-          value: utilization,
-          unit: "Percent",
-        }
-      end
-
-      processes.group_by do |process|
-        process["tag"]
-      end.each do |(tag, tag_processes)|
-        next if tag.nil?
-
-        tag_utilization = calculate_utilization(tag_processes) * 100.0
-
-        unless tag_utilization.nan?
-          metrics << {
-            metric_name: "Utilization",
-            dimensions: [{name: "Tag", value: tag}],
-            timestamp: now,
-            value: tag_utilization,
-            unit: "Percent",
-          }
-        end
-      end
-
-      if @process_metrics
-        processes.each do |process|
-          process_utilization = process["busy"] / process["concurrency"].to_f * 100.0
-
-          unless process_utilization.nan?
-            process_dimensions = [{name: "Hostname", value: process["hostname"]}]
-
-            if process["tag"]
-              process_dimensions << {name: "Tag", value: process["tag"]}
-            end
-
-            metrics << {
-              metric_name: "Utilization",
-              dimensions: process_dimensions,
-              timestamp: now,
-              value: process_utilization,
-              unit: "Percent",
-            }
-          end
-        end
-      end
-
-      queues.each do |(queue_name, queue_size)|
-        metrics << {
-          metric_name: "QueueSize",
-          dimensions: [{name: "QueueName", value: queue_name}],
-          timestamp: now,
-          value: queue_size,
-          unit: "Count",
-        }
-
-        queue_latency = Sidekiq::Queue.new(queue_name).latency
-
-        metrics << {
-          metric_name: "QueueLatency",
-          dimensions: [{name: "QueueName", value: queue_name}],
-          timestamp: now,
-          value: queue_latency,
-          unit: "Seconds",
-        }
-      end
-
-      unless @additional_dimensions.empty?
-        metrics = metrics.each do |metric|
-          metric[:dimensions] = (metric[:dimensions] || []) + @additional_dimensions
-        end
-      end
-
-      metrics
-    end
-
-    # Returns the total number of workers across all processes
-    private def calculate_capacity(processes)
-      processes.map do |process|
-        process["concurrency"]
-      end.sum
-    end
-
-    # Returns busy / concurrency averaged across processes (for scaling)
-    # Avoid considering processes not yet running any threads
-    private def calculate_utilization(processes)
-      process_utilizations = processes.map do |process|
-        process["busy"] / process["concurrency"].to_f
-      end.reject(&:nan?)
-
-      process_utilizations.sum / process_utilizations.size.to_f
     end
 
     def quiet

--- a/sidekiq-cloudwatchmetrics.gemspec
+++ b/sidekiq-cloudwatchmetrics.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
 Gem::Specification.new do |spec|
   spec.name          = "sidekiq-cloudwatchmetrics"
-  spec.version       = "2.6.0"
+  spec.version       = "2.6.1"
   spec.author        = "Samuel Cochran"
   spec.email         = "sj26@sj26.com"
 

--- a/spec/sidekiq/cloudwatchmetrics_spec.rb
+++ b/spec/sidekiq/cloudwatchmetrics_spec.rb
@@ -278,7 +278,8 @@ RSpec.describe Sidekiq::CloudWatchMetrics do
       end
 
       context "with custom dimensions" do
-        subject(:publisher) { Sidekiq::CloudWatchMetrics::Publisher.new(client: client, additional_dimensions: {appCluster: 1, type: "foo"}) }
+        let(:collector) { Sidekiq::CloudWatchMetrics::Collector.new(additional_dimensions: {appCluster: 1, type: "foo"}) }
+        subject(:publisher) { Sidekiq::CloudWatchMetrics::Publisher.new(client: client, collector: collector) }
 
         it "publishes metrics with custom dimensions" do
           Timecop.freeze(now = Time.now) do
@@ -369,7 +370,8 @@ RSpec.describe Sidekiq::CloudWatchMetrics do
       end
 
       context "when per process metrics are disabled" do
-        subject(:publisher) { Sidekiq::CloudWatchMetrics::Publisher.new(client: client, process_metrics: false) }
+        let(:collector) { Sidekiq::CloudWatchMetrics::Collector.new(process_metrics: false) }
+        subject(:publisher) { Sidekiq::CloudWatchMetrics::Publisher.new(client: client, collector: collector) }
 
         it "only publishes a single Utilization metric" do
           Timecop.freeze(now = Time.now) do


### PR DESCRIPTION
Split `Publisher` class into two: `Publisher` and `Collector`.

`Collector` is responsible only for collecting metrics therefore it is easy to extend with custom metrics:

```ruby
class CustomCollector < Sidekiq::CloudWatchMetrics::Collector
  def collect
    metrics = super

    metrics << {
      metric_name: 'MaxQueueLatency',
      timestamp: Time.current,
      value: Sidekiq::Queue.all.map(&:latency).max,
      unit: 'Seconds'
    }

    metrics
  end
end

Sidekiq::CloudWatchMetrics.enable!(collector: CustomCollector.new)
```