### PR TITLE
Allow setting of a publishing interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ The default namespace for metrics is "Sidekiq". You can configure this with the 
 Sidekiq::CloudWatchMetrics.enable!(client: Aws::CloudWatch::Client.new, namespace: "Sidekiq-Staging")
 ```
 
+Publishing interval by default is 60 seconds. You can adjust this as follows:
+
+```ruby
+Sidekiq::CloudWatchMetrics.enable!(client: Aws::CloudWatch::Client.new, interval: 30)
+```
+
 
 ## Development
 

--- a/lib/sidekiq/cloudwatchmetrics.rb
+++ b/lib/sidekiq/cloudwatchmetrics.rb
@@ -45,11 +45,12 @@ module Sidekiq::CloudWatchMetrics
 
     INTERVAL = 60 # seconds
 
-    def initialize(config: Sidekiq, client: Aws::CloudWatch::Client.new, namespace: "Sidekiq", process_metrics: true, additional_dimensions: {})
+    def initialize(config: Sidekiq, client: Aws::CloudWatch::Client.new, namespace: "Sidekiq", process_metrics: true, additional_dimensions: {}, interval: INTERVAL)
       # Sidekiq 6.5+ requires @config, which defaults to the top-level
       # `Sidekiq` module, but can be overridden when running multiple Sidekiqs.
       @config = config
       @client = client
+      @interval = interval
       @namespace = namespace
       @process_metrics = process_metrics
       @additional_dimensions = additional_dimensions.map { |k, v| {name: k.to_s, value: v.to_s} }
@@ -69,7 +70,7 @@ module Sidekiq::CloudWatchMetrics
     def run
       logger.info { "Started Sidekiq CloudWatch Metrics Publisher" }
 
-      # Publish stats every INTERVAL seconds, sleeping as required between runs
+      # Publish stats every @interval seconds, sleeping as required between runs
       now = Time.now.to_f
       tick = now
       until @stop
@@ -77,7 +78,7 @@ module Sidekiq::CloudWatchMetrics
         publish
 
         now = Time.now.to_f
-        tick = [tick + INTERVAL, now].max
+        tick = [tick + @interval, now].max
         sleep(tick - now) if tick > now
       end
 

--- a/lib/sidekiq/cloudwatchmetrics.rb
+++ b/lib/sidekiq/cloudwatchmetrics.rb
@@ -50,7 +50,7 @@ module Sidekiq::CloudWatchMetrics
       # `Sidekiq` module, but can be overridden when running multiple Sidekiqs.
       @config = config
       @client = client
-      @interval = interval
+      @interval = interval || INTERVAL
       @namespace = namespace
       @process_metrics = process_metrics
       @additional_dimensions = additional_dimensions.map { |k, v| {name: k.to_s, value: v.to_s} }

--- a/spec/sidekiq/cloudwatchmetrics_spec.rb
+++ b/spec/sidekiq/cloudwatchmetrics_spec.rb
@@ -207,31 +207,29 @@ RSpec.describe Sidekiq::CloudWatchMetrics do
             ),
           )
         end
+      end
 
-        describe 'Overriding publishing interval' do
-          shared_examples 'a metric publisher' do
-            it "Publishes #{times} times" do      
-              Timecop.freeze(now = Time.now) do
-                expect(client).to receive(:put_metric_data).exactly(times).times
-                publisher.run
-                sleep(interval)
-              end
-            end
+      describe 'Overriding publishing interval' do
+        shared_examples 'a metric publisher' do
+          it "Publishes the correct number of times" do
+            expect(client).to receive(:put_metric_data).exactly(times).times
+            publisher.start
+            sleep(1.2)
+            publisher.stop
           end
-              
-          context 'Default interval (60 seconds)' do
-            let(:times) { 1 }
+        end
 
-            it_behaves_like "a metric publisher" 
-          end
+        context 'Default interval (60 seconds)' do
+          let(:times) { 1 }
 
-          context 'Short interval (1 second)' do
-            let(:times) { 2 }
-            let(:interval) { 1 }
-            
-            it_behaves_like "a metric publisher" 
+          it_behaves_like "a metric publisher"
+        end
 
+        context 'Short interval (1 second)' do
+          let(:times) { 2 }
+          let(:interval) { 1 }
 
+          it_behaves_like "a metric publisher"
         end
       end
 

--- a/spec/sidekiq/cloudwatchmetrics_spec.rb
+++ b/spec/sidekiq/cloudwatchmetrics_spec.rb
@@ -50,9 +50,10 @@ RSpec.describe Sidekiq::CloudWatchMetrics do
 
   describe "Publisher" do
     let(:client) { instance_double(Aws::CloudWatch::Client) }
+    let(:interval) { nil }
     before { allow(client).to receive(:put_metric_data) }
 
-    subject(:publisher) { Sidekiq::CloudWatchMetrics::Publisher.new(client: client) }
+    subject(:publisher) { Sidekiq::CloudWatchMetrics::Publisher.new(client: client, interval: interval) }
 
     describe "#publish" do
       let(:stats) do
@@ -205,6 +206,32 @@ RSpec.describe Sidekiq::CloudWatchMetrics do
               },
             ),
           )
+        end
+
+        describe 'Overriding publishing interval' do
+          shared_examples 'a metric publisher' do
+            it "Publishes #{times} times" do      
+              Timecop.freeze(now = Time.now) do
+                expect(client).to receive(:put_metric_data).exactly(times).times
+                publisher.run
+                sleep(interval)
+              end
+            end
+          end
+              
+          context 'Default interval (60 seconds)' do
+            let(:times) { 1 }
+
+            it_behaves_like "a metric publisher" 
+          end
+
+          context 'Short interval (1 second)' do
+            let(:times) { 2 }
+            let(:interval) { 1 }
+            
+            it_behaves_like "a metric publisher" 
+
+
         end
       end
 


### PR DESCRIPTION
Picking up on @decaffeinatedio's [pull request](https://github.com/sj26/sidekiq-cloudwatchmetrics/pull/36/), this change allows the developer to set a publishing frequency.

This is useful for us as we autoscale on utilisation metric and once every 60 seconds isn't neccessarily fine grained enough.

## Test output

```bash
lloyd@xps13:~/Code/sidekiq-cloudwatchmetrics$ rspec

Sidekiq::CloudWatchMetrics
  .enable!
    in a sidekiq server
      creates a metrics publisher and installs hooks
    in client mode
      does nothing
  Publisher
    #publish
      publishes sidekiq metrics to cloudwatch
      Overriding publishing interval
        Default interval (60 seconds)
          behaves like a metric publisher
2024-03-05T13:16:15.697Z pid=594112 tid=cne0 INFO: Started Sidekiq CloudWatch Metrics Publisher
            Publishes the correct number of times
        Short interval (1 second)
          behaves like a metric publisher
2024-03-05T13:16:16.906Z pid=594112 tid=cnnw INFO: Started Sidekiq CloudWatch Metrics Publisher
            Publishes the correct number of times
      with lots of queues
        publishes sidekiq metrics to cloudwatch in batches of 20
      with process tags
        publishes metrics including tag as a dimension
      with custom dimensions
        publishes metrics with custom dimensions
      with a custom namespace
        publishes metrics with the specified namespace
      when there are no processes yet
        does not publish Utilization (to avoid NaN values)
      when the only process has no threads yet
        does not publish Utilization (to avoid NaN values)
      when only one process has no threads yet
        publishes partial Utilization (to avoid NaN values)
      when per process metrics are disabled
        only publishes a single Utilization metric
    #stop
      doesn't raise ThreadError

Finished in 2.5 seconds (files took 0.52256 seconds to load)
14 examples, 0 failures

lloyd@xps13:~/Code/sidekiq-cloudwatchmetrics$