### PR TITLE
Track capacity by tag

### DIFF
--- a/lib/sidekiq/cloudwatchmetrics.rb
+++ b/lib/sidekiq/cloudwatchmetrics.rb
@@ -169,12 +169,22 @@ module Sidekiq::CloudWatchMetrics
       end.each do |(tag, tag_processes)|
         next if tag.nil?
 
+        tag_dimensions = [{name: "Tag", value: tag}]
+
+        metrics << {
+          metric_name: "Capacity",
+          dimensions: tag_dimensions,
+          timestamp: now,
+          value: calculate_capacity(tag_processes),
+          unit: "Count",
+        }
+
         tag_utilization = calculate_utilization(tag_processes) * 100.0
 
         unless tag_utilization.nan?
           metrics << {
             metric_name: "Utilization",
-            dimensions: [{name: "Tag", value: tag}],
+            dimensions: tag_dimensions,
             timestamp: now,
             value: tag_utilization,
             unit: "Percent",

--- a/spec/sidekiq/cloudwatchmetrics_spec.rb
+++ b/spec/sidekiq/cloudwatchmetrics_spec.rb
@@ -225,8 +225,9 @@ RSpec.describe Sidekiq::CloudWatchMetrics do
       context "with process tags" do
         let(:processes) do
           [
-            Sidekiq::Process.new("busy" => 5, "concurrency" => 10, "hostname" => "foo", "tag" => "default"),
+            Sidekiq::Process.new("busy" => 5, "concurrency" => 5, "hostname" => "foo", "tag" => "default"),
             Sidekiq::Process.new("busy" => 2, "concurrency" => 20, "hostname" => "bar", "tag" => "shard-one"),
+            Sidekiq::Process.new("busy" => 0, "concurrency" => 5, "hostname" => "baz", "tag" => "default"),
           ]
         end
 
@@ -240,8 +241,15 @@ RSpec.describe Sidekiq::CloudWatchMetrics do
                 {
                   metric_name: "Utilization",
                   timestamp: now,
-                  value: 30.0,
+                  value: 36.66666666666667,
                   unit: "Percent",
+                },
+                {
+                  metric_name: "Capacity",
+                  dimensions: [{name: "Tag", value: "default"}],
+                  timestamp: now,
+                  unit: "Count",
+                  value: 10,
                 },
                 {
                   metric_name: "Utilization",
@@ -249,6 +257,13 @@ RSpec.describe Sidekiq::CloudWatchMetrics do
                   timestamp: now,
                   value: 50.0,
                   unit: "Percent",
+                },
+                {
+                  metric_name: "Capacity",
+                  dimensions: [{name: "Tag", value: "shard-one"}],
+                  timestamp: now,
+                  unit: "Count",
+                  value: 20,
                 },
                 {
                   metric_name: "Utilization",
@@ -262,7 +277,7 @@ RSpec.describe Sidekiq::CloudWatchMetrics do
                   dimensions: [{name: "Hostname", value: "foo"}, {name: "Tag", value: "default"}],
                   timestamp: now,
                   unit: "Percent",
-                  value: 50.0,
+                  value: 100.0,
                 },
                 {
                   metric_name: "Utilization",
@@ -270,6 +285,13 @@ RSpec.describe Sidekiq::CloudWatchMetrics do
                   timestamp: now,
                   unit: "Percent",
                   value: 10.0,
+                },
+                {
+                  metric_name: "Utilization",
+                  dimensions: [{name: "Hostname", value: "baz"}, {name: "Tag", value: "default"}],
+                  timestamp: now,
+                  unit: "Percent",
+                  value: 0.0,
                 },
               ),
             )


### PR DESCRIPTION
"Capacity" is what Sidekiq calls "concurrency", the total number of threads across every process, i.e. `Sidekiq::ProcessSet.new.total_concurrency`.

We would like that metric broken down by tag.

I have added an extra host to the test to ensure the concurrency is calculated accurately across multiple hosts.