### PR TITLE
Sidekiq 8 Compatiblity

### DIFF
--- a/lib/sidekiq/cloudwatchmetrics.rb
+++ b/lib/sidekiq/cloudwatchmetrics.rb
@@ -45,7 +45,7 @@ module Sidekiq::CloudWatchMetrics
 
     DEFAULT_INTERVAL = 60 # seconds
 
-    def initialize(config: Sidekiq, client: Aws::CloudWatch::Client.new, namespace: "Sidekiq", process_metrics: true, additional_dimensions: {}, interval: DEFAULT_INTERVAL)
+    def initialize(config: Sidekiq::Config.new, client: Aws::CloudWatch::Client.new, namespace: "Sidekiq", process_metrics: true, additional_dimensions: {}, interval: DEFAULT_INTERVAL)
       # Sidekiq 6.5+ requires @config, which defaults to the top-level
       # `Sidekiq` module, but can be overridden when running multiple Sidekiqs.
       @config = config

--- a/sidekiq-cloudwatchmetrics.gemspec
+++ b/sidekiq-cloudwatchmetrics.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
 Gem::Specification.new do |spec|
   spec.name          = "sidekiq-cloudwatchmetrics"
-  spec.version       = "2.7.0"
+  spec.version       = "2.8.0"
   spec.author        = "Samuel Cochran"
   spec.email         = "sj26@sj26.com"
 
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.7"
 
-  spec.add_runtime_dependency "sidekiq", ">= 5.0", "< 8.0"
+  spec.add_runtime_dependency "sidekiq", ">= 5.0", "< 9.0"
   spec.add_runtime_dependency "aws-sdk-cloudwatch", "~> 1.6"
 
   spec.add_development_dependency "bundler", "~> 2.2"


### PR DESCRIPTION
Make this gem compatible with sidekiq version 8

* Updated the `sidekiq` dependency in `sidekiq-cloudwatchmetrics.gemspec` to '>= 5.0', '< 9.0'
* Changed the `Publisher#initialize` method in `lib/sidekiq/cloudwatchmetrics.rb` to default the `config` argument to `Sidekiq::Config.new`. This was necessary due to [this change](https://github.com/sidekiq/sidekiq/commit/51d01726b9816ee2e88065e4edfa8d05be986842#diff-834a0ef3592975c4c6cc3ef43d6042747bbb615541e54336511692076b36b379R37) in version 8 of `sidekiq`