### PR TITLE
Sidekiq 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,12 @@ jobs:
       matrix:
         ruby-version: ['2.7', '3.0', '3.1', '3.2']
         bundle-gemfile: ['Gemfile', 'Gemfile.sidekiq-5', 'Gemfile.sidekiq-6', 'Gemfile.sidekiq-6-0', 'Gemfile.sidekiq-7', 'Gemfile.sidekiq-8']
+        exclude:
+          # Sidekiq 8 requires ruby >= 3.2
+          - { bundle-gemfile: 'Gemfile.sidekiq-8', ruby-version: '2.7' }
+          - { bundle-gemfile: 'Gemfile.sidekiq-8', ruby-version: '3.0' }
+          - { bundle-gemfile: 'Gemfile.sidekiq-8', ruby-version: '3.1' }
+
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version: ['2.7', '3.0', '3.1', '3.2']
-        bundle-gemfile: ['Gemfile', 'Gemfile.sidekiq-5', 'Gemfile.sidekiq-6', 'Gemfile.sidekiq-6-0', 'Gemfile.sidekiq-7']
+        bundle-gemfile: ['Gemfile', 'Gemfile.sidekiq-5', 'Gemfile.sidekiq-6', 'Gemfile.sidekiq-6-0', 'Gemfile.sidekiq-7', 'Gemfile.sidekiq-8']
 
     steps:
     - uses: actions/checkout@v2

--- a/Gemfile.sidekiq-8
+++ b/Gemfile.sidekiq-8
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+# Specify your gem's dependencies in sidekiq-cloudwatch.gemspec
+gemspec
+
+gem "sidekiq", "~> 8.0"

--- a/lib/sidekiq/cloudwatchmetrics.rb
+++ b/lib/sidekiq/cloudwatchmetrics.rb
@@ -45,7 +45,7 @@ module Sidekiq::CloudWatchMetrics
 
     DEFAULT_INTERVAL = 60 # seconds
 
-    def initialize(config: Sidekiq, client: Aws::CloudWatch::Client.new, namespace: "Sidekiq", process_metrics: true, additional_dimensions: {}, interval: DEFAULT_INTERVAL)
+    def initialize(config: Sidekiq::Config.new, client: Aws::CloudWatch::Client.new, namespace: "Sidekiq", process_metrics: true, additional_dimensions: {}, interval: DEFAULT_INTERVAL)
       # Sidekiq 6.5+ requires @config, which defaults to the top-level
       # `Sidekiq` module, but can be overridden when running multiple Sidekiqs.
       @config = config

--- a/lib/sidekiq/cloudwatchmetrics.rb
+++ b/lib/sidekiq/cloudwatchmetrics.rb
@@ -8,7 +8,7 @@ require "aws-sdk-cloudwatch"
 module Sidekiq::CloudWatchMetrics
   def self.enable!(**kwargs)
     Sidekiq.configure_server do |config|
-      publisher = Publisher.new(**kwargs)
+      publisher = Publisher.new(config: config, **kwargs)
 
       # Sidekiq enterprise has a globally unique leader thread, making it
       # easier to publish the cluster-wide metrics from one place.

--- a/lib/sidekiq/cloudwatchmetrics.rb
+++ b/lib/sidekiq/cloudwatchmetrics.rb
@@ -45,10 +45,20 @@ module Sidekiq::CloudWatchMetrics
 
     DEFAULT_INTERVAL = 60 # seconds
 
-    def initialize(config: Sidekiq::Config.new, client: Aws::CloudWatch::Client.new, namespace: "Sidekiq", process_metrics: true, additional_dimensions: {}, interval: DEFAULT_INTERVAL)
-      # Sidekiq 6.5+ requires @config, which defaults to the top-level
-      # `Sidekiq` module, but can be overridden when running multiple Sidekiqs.
+    private def default_config
+      # Sidekiq::Config was introduced in sidekiq 7 and has a default
+      if Sidekiq.respond_to?(:default_configuration)
+        Sidekiq.default_configuration
+      else
+        # in older versions, it's just the `Sidekiq` module
+        Sidekiq
+      end
+    end
+
+    def initialize(config: default_config, client: Aws::CloudWatch::Client.new, namespace: "Sidekiq", process_metrics: true, additional_dimensions: {}, interval: DEFAULT_INTERVAL)
+      # Required by Sidekiq::Component (in sidekiq 6.5+)
       @config = config
+
       @client = client
       @interval = interval
       @namespace = namespace

--- a/sidekiq-cloudwatchmetrics.gemspec
+++ b/sidekiq-cloudwatchmetrics.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
 Gem::Specification.new do |spec|
   spec.name          = "sidekiq-cloudwatchmetrics"
-  spec.version       = "2.7.0"
+  spec.version       = "2.8.0"
   spec.author        = "Samuel Cochran"
   spec.email         = "sj26@sj26.com"
 
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.7"
 
-  spec.add_runtime_dependency "sidekiq", ">= 5.0", "< 8.0"
+  spec.add_runtime_dependency "sidekiq", ">= 5.0", "<= 8.0"
   spec.add_runtime_dependency "aws-sdk-cloudwatch", "~> 1.6"
 
   spec.add_development_dependency "bundler", "~> 2.2"

--- a/sidekiq-cloudwatchmetrics.gemspec
+++ b/sidekiq-cloudwatchmetrics.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.7"
 
-  spec.add_runtime_dependency "sidekiq", ">= 5.0", "<= 8.0"
+  spec.add_runtime_dependency "sidekiq", ">= 5.0", "< 9.0"
   spec.add_runtime_dependency "aws-sdk-cloudwatch", "~> 1.6"
 
   spec.add_development_dependency "bundler", "~> 2.2"

--- a/sidekiq-cloudwatchmetrics.gemspec
+++ b/sidekiq-cloudwatchmetrics.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
 Gem::Specification.new do |spec|
   spec.name          = "sidekiq-cloudwatchmetrics"
-  spec.version       = "2.8.0"
+  spec.version       = "2.7.0"
   spec.author        = "Samuel Cochran"
   spec.email         = "sj26@sj26.com"
 


### PR DESCRIPTION
Builds on #50, which allows the sidekiq 8.0+ gems, but adds backwards compatibility and ensures the default Sidekiq configuration is shared correctly on Sidekiq 7+.

Fixes #51. Closes #50.