### PR TITLE
Add high resolution storage support

### DIFF
--- a/lib/sidekiq/cloudwatchmetrics.rb
+++ b/lib/sidekiq/cloudwatchmetrics.rb
@@ -258,6 +258,9 @@ module Sidekiq::CloudWatchMetrics
 
       # We can only put 20 metrics at a time
       metrics.each_slice(20) do |some_metrics|
+        if @interval_s < 60
+          metrics.each { |metric| metric.merge!(storage_resolution: 1) }
+        end
         @client.put_metric_data(
           namespace: @namespace,
           metric_data: some_metrics,


### PR DESCRIPTION
[High-resolution metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html#high-resolution-metrics) allow you to view metrics at a 1s granularity. This can be useful for viewing these metrics as well as enabling high-resolution alarms for auto-scaling.

There's no additional cost for setting the higher storage resolution, you're charged per PutMetricData API call and so it's the change in interval that triggers the higher cost. Hence there's no change in pricing based on adding this functionality.