### PR TITLE
Add job execution time metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,68 @@ Metrics are published every 60 seconds by default. You can adjust this with the 
 Sidekiq::CloudWatchMetrics.enable!(interval: 30)
 ```
 
+When the interval is less than 60 seconds the metrics are published as
+[high-resolution metrics][highres] (1-second storage resolution), suitable for
+fast-reacting alarms and burst auto-scaling.
+
+  [highres]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html#high-resolution-metrics
+
+### Choosing which metrics to publish
+
+By default every metric is published. To opt in to a subset, pass a `metrics:`
+array of symbols:
+
+```ruby
+# Just publish queue depth + latency, useful for autoscaling alarms
+Sidekiq::CloudWatchMetrics.enable!(
+  interval: 10,
+  metrics: %i[queue_size queue_latency],
+)
+```
+
+The publisher skips the upstream Sidekiq calls it doesn't need — e.g. if you
+only ask for queue metrics it won't enumerate the process set, and if you only
+ask for global stats it won't iterate queues.
+
+`enable!` may be called multiple times to register additional publishers with
+different cadences and filters. For example, a slow full-fat publisher plus a
+fast queue-only publisher for burst scaling:
+
+```ruby
+Sidekiq::CloudWatchMetrics.enable!  # everything, every 60s
+Sidekiq::CloudWatchMetrics.enable!(
+  interval: 10,
+  metrics: %i[queue_size queue_latency],
+)
+```
+
+Available metric keys:
+
+| Symbol                  | CloudWatch metric     | Scope                                  |
+| ----------------------- | --------------------- | -------------------------------------- |
+| `:processed_jobs`       | `ProcessedJobs`       | global                                 |
+| `:failed_jobs`          | `FailedJobs`          | global                                 |
+| `:enqueued_jobs`        | `EnqueuedJobs`        | global                                 |
+| `:scheduled_jobs`       | `ScheduledJobs`       | global                                 |
+| `:retry_jobs`           | `RetryJobs`           | global                                 |
+| `:dead_jobs`            | `DeadJobs`            | global                                 |
+| `:workers`              | `Workers`             | global                                 |
+| `:processes`            | `Processes`           | global                                 |
+| `:default_queue_latency`| `DefaultQueueLatency` | global                                 |
+| `:capacity`             | `Capacity`            | global aggregate over all processes    |
+| `:utilization`          | `Utilization`         | global aggregate over all processes    |
+| `:tag_capacity`         | `Capacity`            | per process tag                        |
+| `:tag_utilization`      | `Utilization`         | per process tag                        |
+| `:process_utilization`  | `Utilization`         | per process (Hostname dimension)       |
+| `:queue_size`           | `QueueSize`           | per queue                              |
+| `:queue_latency`        | `QueueLatency`        | per queue                              |
+
+Unknown symbols raise `ArgumentError` at boot.
+
+The legacy `process_metrics:` boolean is still accepted for backwards
+compatibility but emits a deprecation warning — prefer the `metrics:` option
+(omit `:process_utilization` to disable per-process utilization).
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/README.md
+++ b/README.md
@@ -105,8 +105,21 @@ Available metric keys:
 | `:process_utilization`  | `Utilization`         | per process (Hostname dimension)       |
 | `:queue_size`           | `QueueSize`           | per queue                              |
 | `:queue_latency`        | `QueueLatency`        | per queue                              |
+| `:job_execution_time_p50` | `JobExecutionTimeP50` | per job class (Sidekiq 7+)           |
+| `:job_execution_time_p95` | `JobExecutionTimeP95` | per job class (Sidekiq 7+)           |
+| `:job_execution_time_p99` | `JobExecutionTimeP99` | per job class (Sidekiq 7+)           |
 
 Unknown symbols raise `ArgumentError` at boot.
+
+The `job_execution_time_*` metrics are derived from the execution histograms
+Sidekiq 7+ records in Redis via its built-in `ExecutionTracker` middleware.
+Each tick reads the previous full minute's histograms once and computes the
+requested percentiles from the bucket counts (resolution is whichever
+`Sidekiq::Metrics::Histogram::BUCKET_INTERVALS` bucket the percentile falls
+into — e.g. `1.7s`, `2.5s`, `3.8s`). They are silently skipped on Sidekiq
+versions that don't ship `Sidekiq::Metrics`. Use them on the standard 60s
+publisher, not on burst publishers — the source data only updates once per
+minute.
 
 The legacy `process_metrics:` boolean is still accepted for backwards
 compatibility but emits a deprecation warning — prefer the `metrics:` option

--- a/lib/sidekiq/cloudwatchmetrics.rb
+++ b/lib/sidekiq/cloudwatchmetrics.rb
@@ -64,12 +64,27 @@ module Sidekiq::CloudWatchMetrics
     PROCESS_METRICS = %i[process_utilization].freeze
     QUEUE_METRICS = %i[queue_size queue_latency].freeze
 
+    # Per-job-class execution time percentiles, derived from the histogram data
+    # Sidekiq 7+ records in Redis via Sidekiq::Metrics::ExecutionTracker.
+    EXECUTION_HISTOGRAM_METRICS = %i[
+      job_execution_time_p50
+      job_execution_time_p95
+      job_execution_time_p99
+    ].freeze
+
+    EXECUTION_HISTOGRAM_PERCENTILES = {
+      job_execution_time_p50: [0.50, "JobExecutionTimeP50"],
+      job_execution_time_p95: [0.95, "JobExecutionTimeP95"],
+      job_execution_time_p99: [0.99, "JobExecutionTimeP99"],
+    }.freeze
+
     ALL_METRICS = (
       GLOBAL_STATS_METRICS +
       GLOBAL_AGGREGATE_METRICS +
       TAG_METRICS +
       PROCESS_METRICS +
-      QUEUE_METRICS
+      QUEUE_METRICS +
+      EXECUTION_HISTOGRAM_METRICS
     ).freeze
 
     private def default_config
@@ -215,6 +230,19 @@ module Sidekiq::CloudWatchMetrics
         end
       end
 
+      if enabled_any?(EXECUTION_HISTOGRAM_METRICS) && execution_histograms_supported?
+        fetch_recent_execution_histograms.each do |klass, buckets|
+          job_dimensions = [{name: "JobClass", value: klass}]
+          EXECUTION_HISTOGRAM_METRICS.each do |key|
+            next unless enabled?(key)
+            percentile, metric_name = EXECUTION_HISTOGRAM_PERCENTILES.fetch(key)
+            seconds = percentile_seconds(buckets, percentile)
+            next if seconds.nil?
+            metrics << build_metric(metric_name, seconds, now, unit: "Seconds", dimensions: job_dimensions)
+          end
+        end
+      end
+
       unless @additional_dimensions.empty?
         metrics.each do |metric|
           metric[:dimensions] = (metric[:dimensions] || []) + @additional_dimensions
@@ -272,6 +300,55 @@ module Sidekiq::CloudWatchMetrics
       end
 
       enabled
+    end
+
+    # Sidekiq 7 introduced the in-process ExecutionTracker, which records
+    # per-class execution time histograms in Redis. The publisher reads those
+    # histograms (not raw timings) so each tick is cheap regardless of throughput.
+    private def execution_histograms_supported?
+      defined?(Sidekiq::Metrics::Query) && defined?(Sidekiq::Metrics::Histogram)
+    end
+
+    # The ExecutionTracker flushes to Redis on each Sidekiq heartbeat (~10s),
+    # so we query the previous full minute to avoid racing an in-progress flush.
+    # Returns { class_name => [bucket_count, ...] } for classes with activity.
+    private def fetch_recent_execution_histograms
+      query_time = Time.now - 60
+      query = Sidekiq::Metrics::Query.new(now: query_time)
+      result = query.top_jobs(minutes: 1)
+      return {} if result.job_results.empty?
+
+      histograms = {}
+      Sidekiq.redis do |conn|
+        result.job_results.each_key do |klass|
+          buckets = Sidekiq::Metrics::Histogram.new(klass).fetch(conn, query_time)
+          next if buckets.nil? || buckets.sum.zero?
+          histograms[klass] = buckets
+        end
+      end
+      histograms
+    end
+
+    # Computes a percentile from Sidekiq's 26-bucket execution histogram.
+    # Each bucket's upper bound comes from Sidekiq::Metrics::Histogram::BUCKET_INTERVALS;
+    # we report that upper bound (a conservative over-estimate). The final
+    # "Slow" bucket has an effectively infinite upper bound, so we clamp it to
+    # the previous bucket's upper bound to keep the published value plottable.
+    private def percentile_seconds(buckets, percentile)
+      total = buckets.sum
+      return nil if total.zero?
+
+      intervals = Sidekiq::Metrics::Histogram::BUCKET_INTERVALS
+      last_index = intervals.size - 1
+      target = total * percentile
+      cumulative = 0
+      buckets.each_with_index do |count, idx|
+        cumulative += count
+        next if cumulative < target
+        upper_ms = (idx == last_index) ? intervals[last_index - 1] : intervals[idx]
+        return upper_ms / 1000.0
+      end
+      nil
     end
 
     # Returns the total number of workers across all processes

--- a/lib/sidekiq/cloudwatchmetrics.rb
+++ b/lib/sidekiq/cloudwatchmetrics.rb
@@ -45,6 +45,33 @@ module Sidekiq::CloudWatchMetrics
 
     DEFAULT_INTERVAL = 60 # seconds
 
+    # Metric keys grouped by the upstream Sidekiq data they need, so the
+    # publisher can skip work it doesn't have to do on each tick.
+    GLOBAL_STATS_METRICS = %i[
+      processed_jobs
+      failed_jobs
+      enqueued_jobs
+      scheduled_jobs
+      retry_jobs
+      dead_jobs
+      workers
+      processes
+      default_queue_latency
+    ].freeze
+
+    GLOBAL_AGGREGATE_METRICS = %i[capacity utilization].freeze
+    TAG_METRICS = %i[tag_capacity tag_utilization].freeze
+    PROCESS_METRICS = %i[process_utilization].freeze
+    QUEUE_METRICS = %i[queue_size queue_latency].freeze
+
+    ALL_METRICS = (
+      GLOBAL_STATS_METRICS +
+      GLOBAL_AGGREGATE_METRICS +
+      TAG_METRICS +
+      PROCESS_METRICS +
+      QUEUE_METRICS
+    ).freeze
+
     private def default_config
       # Sidekiq::Config was introduced in sidekiq 7 and has a default
       if Sidekiq.respond_to?(:default_configuration)
@@ -55,15 +82,16 @@ module Sidekiq::CloudWatchMetrics
       end
     end
 
-    def initialize(config: default_config, client: Aws::CloudWatch::Client.new, namespace: "Sidekiq", process_metrics: true, additional_dimensions: {}, interval: DEFAULT_INTERVAL)
+    def initialize(config: default_config, client: Aws::CloudWatch::Client.new, namespace: "Sidekiq", process_metrics: nil, additional_dimensions: {}, interval: DEFAULT_INTERVAL, metrics: nil)
       # Required by Sidekiq::Component (in sidekiq 6.5+)
       @config = config
 
       @client = client
       @interval_s = interval
       @namespace = namespace
-      @process_metrics = process_metrics
       @additional_dimensions = additional_dimensions.map { |k, v| {name: k.to_s, value: v.to_s} }
+
+      @enabled_metrics = resolve_enabled_metrics(metrics, process_metrics)
     end
 
     def start
@@ -102,170 +130,148 @@ module Sidekiq::CloudWatchMetrics
 
     def publish
       now = Time.now
-      stats = Sidekiq::Stats.new
-      processes = Sidekiq::ProcessSet.new.to_enum(:each).to_a
-      queues = stats.queues
+      metrics = []
 
-      metrics = [
-        {
-          metric_name: "ProcessedJobs",
-          timestamp: now,
-          value: stats.processed,
-          unit: "Count",
-        },
-        {
-          metric_name: "FailedJobs",
-          timestamp: now,
-          value: stats.failed,
-          unit: "Count",
-        },
-        {
-          metric_name: "EnqueuedJobs",
-          timestamp: now,
-          value: stats.enqueued,
-          unit: "Count",
-        },
-        {
-          metric_name: "ScheduledJobs",
-          timestamp: now,
-          value: stats.scheduled_size,
-          unit: "Count",
-        },
-        {
-          metric_name: "RetryJobs",
-          timestamp: now,
-          value: stats.retry_size,
-          unit: "Count",
-        },
-        {
-          metric_name: "DeadJobs",
-          timestamp: now,
-          value: stats.dead_size,
-          unit: "Count",
-        },
-        {
-          metric_name: "Workers",
-          timestamp: now,
-          value: stats.workers_size,
-          unit: "Count",
-        },
-        {
-          metric_name: "Processes",
-          timestamp: now,
-          value: stats.processes_size,
-          unit: "Count",
-        },
-        {
-          metric_name: "DefaultQueueLatency",
-          timestamp: now,
-          value: stats.default_queue_latency,
-          unit: "Seconds",
-        },
-        {
-          metric_name: "Capacity",
-          timestamp: now,
-          value: calculate_capacity(processes),
-          unit: "Count",
-        },
-      ]
+      needs_stats = enabled_any?(GLOBAL_STATS_METRICS)
+      needs_processes = enabled_any?(GLOBAL_AGGREGATE_METRICS + TAG_METRICS + PROCESS_METRICS)
+      needs_queues = enabled_any?(QUEUE_METRICS)
 
-      utilization = calculate_utilization(processes) * 100.0
+      # Sidekiq::Stats already fetches queue names and sizes on init, so reuse
+      # it when we need either global stats or per-queue metrics.
+      stats = Sidekiq::Stats.new if needs_stats || needs_queues
+      processes = needs_processes ? Sidekiq::ProcessSet.new.to_enum(:each).to_a : []
 
-      unless utilization.nan?
-        metrics << {
-          metric_name: "Utilization",
-          timestamp: now,
-          value: utilization,
-          unit: "Percent",
-        }
+      if needs_stats
+        metrics << build_metric("ProcessedJobs", stats.processed, now) if enabled?(:processed_jobs)
+        metrics << build_metric("FailedJobs", stats.failed, now) if enabled?(:failed_jobs)
+        metrics << build_metric("EnqueuedJobs", stats.enqueued, now) if enabled?(:enqueued_jobs)
+        metrics << build_metric("ScheduledJobs", stats.scheduled_size, now) if enabled?(:scheduled_jobs)
+        metrics << build_metric("RetryJobs", stats.retry_size, now) if enabled?(:retry_jobs)
+        metrics << build_metric("DeadJobs", stats.dead_size, now) if enabled?(:dead_jobs)
+        metrics << build_metric("Workers", stats.workers_size, now) if enabled?(:workers)
+        metrics << build_metric("Processes", stats.processes_size, now) if enabled?(:processes)
+        metrics << build_metric("DefaultQueueLatency", stats.default_queue_latency, now, unit: "Seconds") if enabled?(:default_queue_latency)
       end
 
-      processes.group_by do |process|
-        process["tag"]
-      end.each do |(tag, tag_processes)|
-        next if tag.nil?
+      if enabled?(:capacity)
+        metrics << build_metric("Capacity", calculate_capacity(processes), now)
+      end
 
-        tag_dimensions = [{name: "Tag", value: tag}]
-
-        metrics << {
-          metric_name: "Capacity",
-          dimensions: tag_dimensions,
-          timestamp: now,
-          value: calculate_capacity(tag_processes),
-          unit: "Count",
-        }
-
-        tag_utilization = calculate_utilization(tag_processes) * 100.0
-
-        unless tag_utilization.nan?
-          metrics << {
-            metric_name: "Utilization",
-            dimensions: tag_dimensions,
-            timestamp: now,
-            value: tag_utilization,
-            unit: "Percent",
-          }
+      if enabled?(:utilization)
+        utilization = calculate_utilization(processes) * 100.0
+        unless utilization.nan?
+          metrics << build_metric("Utilization", utilization, now, unit: "Percent")
         end
       end
 
-      if @process_metrics
-        processes.each do |process|
-          process_utilization = process["busy"] / process["concurrency"].to_f * 100.0
+      if enabled_any?(TAG_METRICS)
+        processes.group_by { |process| process["tag"] }.each do |(tag, tag_processes)|
+          next if tag.nil?
 
-          unless process_utilization.nan?
-            process_dimensions = [{name: "Hostname", value: process["hostname"]}]
+          tag_dimensions = [{name: "Tag", value: tag}]
 
-            if process["tag"] && !process["tag"].to_s.empty?
-              process_dimensions << {name: "Tag", value: process["tag"]}
+          if enabled?(:tag_capacity)
+            metrics << build_metric("Capacity", calculate_capacity(tag_processes), now, dimensions: tag_dimensions)
+          end
+
+          if enabled?(:tag_utilization)
+            tag_utilization = calculate_utilization(tag_processes) * 100.0
+
+            unless tag_utilization.nan?
+              metrics << build_metric("Utilization", tag_utilization, now, unit: "Percent", dimensions: tag_dimensions)
             end
-
-            metrics << {
-              metric_name: "Utilization",
-              dimensions: process_dimensions,
-              timestamp: now,
-              value: process_utilization,
-              unit: "Percent",
-            }
           end
         end
       end
 
-      queues.each do |(queue_name, queue_size)|
-        metrics << {
-          metric_name: "QueueSize",
-          dimensions: [{name: "QueueName", value: queue_name}],
-          timestamp: now,
-          value: queue_size,
-          unit: "Count",
-        }
+      if enabled?(:process_utilization)
+        processes.each do |process|
+          process_utilization = process["busy"] / process["concurrency"].to_f * 100.0
 
-        queue_latency = Sidekiq::Queue.new(queue_name).latency
+          next if process_utilization.nan?
 
-        metrics << {
-          metric_name: "QueueLatency",
-          dimensions: [{name: "QueueName", value: queue_name}],
-          timestamp: now,
-          value: queue_latency,
-          unit: "Seconds",
-        }
+          process_dimensions = [{name: "Hostname", value: process["hostname"]}]
+
+          if process["tag"] && !process["tag"].to_s.empty?
+            process_dimensions << {name: "Tag", value: process["tag"]}
+          end
+
+          metrics << build_metric("Utilization", process_utilization, now, unit: "Percent", dimensions: process_dimensions)
+        end
+      end
+
+      if needs_queues
+        stats.queues.each do |(queue_name, queue_size)|
+          queue_dimensions = [{name: "QueueName", value: queue_name}]
+
+          if enabled?(:queue_size)
+            metrics << build_metric("QueueSize", queue_size, now, dimensions: queue_dimensions)
+          end
+
+          if enabled?(:queue_latency)
+            queue_latency = Sidekiq::Queue.new(queue_name).latency
+            metrics << build_metric("QueueLatency", queue_latency, now, unit: "Seconds", dimensions: queue_dimensions)
+          end
+        end
       end
 
       unless @additional_dimensions.empty?
-        metrics = metrics.each do |metric|
+        metrics.each do |metric|
           metric[:dimensions] = (metric[:dimensions] || []) + @additional_dimensions
         end
       end
 
+      if @interval_s < 60
+        metrics.each { |metric| metric[:storage_resolution] = 1 }
+      end
+
       # We can only put 20 metrics at a time
       metrics.each_slice(20) do |some_metrics|
-        if @interval_s < 60
-          metrics.each { |metric| metric.merge!(storage_resolution: 1) }
-        end
         @client.put_metric_data(
           namespace: @namespace,
           metric_data: some_metrics,
         )
       end
+    end
+
+    private def build_metric(name, value, timestamp, unit: "Count", dimensions: nil)
+      metric = {
+        metric_name: name,
+        timestamp: timestamp,
+        value: value,
+        unit: unit,
+      }
+      metric[:dimensions] = dimensions if dimensions
+      metric
+    end
+
+    private def enabled?(key)
+      @enabled_metrics.include?(key)
+    end
+
+    private def enabled_any?(keys)
+      (@enabled_metrics & keys).any?
+    end
+
+    private def resolve_enabled_metrics(metrics, process_metrics)
+      enabled =
+        if metrics.nil?
+          ALL_METRICS.dup
+        else
+          requested = Array(metrics).map(&:to_sym)
+          unknown = requested - ALL_METRICS
+          if unknown.any?
+            raise ArgumentError, "Unknown metric#{"s" if unknown.size > 1}: #{unknown.inspect}. Available: #{ALL_METRICS.inspect}"
+          end
+          requested
+        end
+
+      unless process_metrics.nil?
+        warn "[sidekiq-cloudwatchmetrics] `process_metrics:` is deprecated; use `metrics:` to choose which metrics to publish (omit `:process_utilization` to disable per-process utilization)."
+        enabled -= [:process_utilization] unless process_metrics
+      end
+
+      enabled
     end
 
     # Returns the total number of workers across all processes

--- a/sidekiq-cloudwatchmetrics.gemspec
+++ b/sidekiq-cloudwatchmetrics.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
 Gem::Specification.new do |spec|
   spec.name          = "sidekiq-cloudwatchmetrics"
-  spec.version       = "2.9.0"
+  spec.version       = "2.10.0"
   spec.author        = "Samuel Cochran"
   spec.email         = "sj26@sj26.com"
 

--- a/spec/sidekiq/cloudwatchmetrics_spec.rb
+++ b/spec/sidekiq/cloudwatchmetrics_spec.rb
@@ -140,6 +140,14 @@ RSpec.describe Sidekiq::CloudWatchMetrics do
         allow(Sidekiq::Stats).to receive(:new).and_return(stats)
         allow(Sidekiq::ProcessSet).to receive(:new).and_return(processes)
         allow(Sidekiq::Queue).to receive(:new) { |name| queues.fetch(name) }
+        # By default neutralize the execution-histogram code path so existing
+        # tests don't need to know about it. The dedicated context below
+        # overrides these stubs to exercise the percentile calculation.
+        if defined?(Sidekiq::Metrics::Query)
+          allow(Sidekiq::Metrics::Query).to receive(:new).and_return(
+            double(top_jobs: double(job_results: {})),
+          )
+        end
       end
 
       it "publishes sidekiq metrics to cloudwatch" do
@@ -650,6 +658,123 @@ RSpec.describe Sidekiq::CloudWatchMetrics do
                 ),
               )
             end
+          end
+        end
+
+        context "selecting job execution time percentiles", if: defined?(Sidekiq::Metrics::Query) do
+          subject(:publisher) do
+            Sidekiq::CloudWatchMetrics::Publisher.new(
+              client: client,
+              metrics: %i[job_execution_time_p50 job_execution_time_p95 job_execution_time_p99],
+            )
+          end
+
+          let(:fake_conn) { double(:redis_conn) }
+
+          # 26-bucket histograms, matching Sidekiq::Metrics::Histogram::BUCKET_INTERVALS.
+          #   FastJob: 100 samples in bucket 0 → every percentile lands at 20ms.
+          let(:fast_job_buckets) { [100] + Array.new(25, 0) }
+
+          # SlowJob: 90 in bucket 0 (≤20ms), 8 in bucket 10 (≤1.1s), 2 in bucket 17 (≤20s).
+          #   p50 → cumulative 90 at idx 0  → 20ms   = 0.02s
+          #   p95 → cumulative 98 at idx 10 → 1100ms = 1.1s
+          #   p99 → cumulative 100 at idx 17 → 20000ms = 20s
+          let(:slow_job_buckets) do
+            Array.new(26, 0).tap do |buckets|
+              buckets[0]  = 90
+              buckets[10] = 8
+              buckets[17] = 2
+            end
+          end
+
+          before do
+            job_results = {"FastJob" => double(:fast_result), "SlowJob" => double(:slow_result)}
+            allow(Sidekiq::Metrics::Query).to receive(:new).and_return(
+              double(top_jobs: double(job_results: job_results)),
+            )
+
+            allow(Sidekiq).to receive(:redis).and_yield(fake_conn)
+
+            fast_hist = double(:fast_histogram, fetch: fast_job_buckets)
+            slow_hist = double(:slow_histogram, fetch: slow_job_buckets)
+            allow(Sidekiq::Metrics::Histogram).to receive(:new).with("FastJob").and_return(fast_hist)
+            allow(Sidekiq::Metrics::Histogram).to receive(:new).with("SlowJob").and_return(slow_hist)
+          end
+
+          it "publishes per-class p50/p95/p99 derived from the execution histograms" do
+            Timecop.freeze(now = Time.now) do
+              publisher.publish
+
+              expect(client).to have_received(:put_metric_data).with(
+                namespace: "Sidekiq",
+                metric_data: contain_exactly(
+                  {metric_name: "JobExecutionTimeP50", dimensions: [{name: "JobClass", value: "FastJob"}], timestamp: now, value: 0.02, unit: "Seconds"},
+                  {metric_name: "JobExecutionTimeP95", dimensions: [{name: "JobClass", value: "FastJob"}], timestamp: now, value: 0.02, unit: "Seconds"},
+                  {metric_name: "JobExecutionTimeP99", dimensions: [{name: "JobClass", value: "FastJob"}], timestamp: now, value: 0.02, unit: "Seconds"},
+                  {metric_name: "JobExecutionTimeP50", dimensions: [{name: "JobClass", value: "SlowJob"}], timestamp: now, value: 0.02, unit: "Seconds"},
+                  {metric_name: "JobExecutionTimeP95", dimensions: [{name: "JobClass", value: "SlowJob"}], timestamp: now, value: 1.1, unit: "Seconds"},
+                  {metric_name: "JobExecutionTimeP99", dimensions: [{name: "JobClass", value: "SlowJob"}], timestamp: now, value: 20.0, unit: "Seconds"},
+                ),
+              )
+            end
+          end
+
+          it "does not call Sidekiq::Stats, ProcessSet, or Queue" do
+            expect(Sidekiq::Stats).not_to receive(:new)
+            expect(Sidekiq::ProcessSet).not_to receive(:new)
+            expect(Sidekiq::Queue).not_to receive(:new)
+            publisher.publish
+          end
+
+          context "when the percentile falls into the final \"Slow\" bucket" do
+            let(:slow_job_buckets) { Array.new(25, 0) + [5] }
+
+            it "clamps to the previous bucket's upper bound to keep the value plottable" do
+              # BUCKET_INTERVALS[24] = 335000 → 335.0s
+              Timecop.freeze(now = Time.now) do
+                publisher.publish
+
+                expect(client).to have_received(:put_metric_data).with(
+                  namespace: "Sidekiq",
+                  metric_data: include(
+                    {metric_name: "JobExecutionTimeP99", dimensions: [{name: "JobClass", value: "SlowJob"}], timestamp: now, value: 335.0, unit: "Seconds"},
+                  ),
+                )
+              end
+            end
+          end
+
+          context "with a class that has no recorded activity" do
+            let(:slow_job_buckets) { Array.new(26, 0) }
+
+            it "publishes nothing for that class" do
+              Timecop.freeze(now = Time.now) do
+                publisher.publish
+
+                expect(client).to have_received(:put_metric_data).with(
+                  namespace: "Sidekiq",
+                  metric_data: contain_exactly(
+                    {metric_name: "JobExecutionTimeP50", dimensions: [{name: "JobClass", value: "FastJob"}], timestamp: now, value: 0.02, unit: "Seconds"},
+                    {metric_name: "JobExecutionTimeP95", dimensions: [{name: "JobClass", value: "FastJob"}], timestamp: now, value: 0.02, unit: "Seconds"},
+                    {metric_name: "JobExecutionTimeP99", dimensions: [{name: "JobClass", value: "FastJob"}], timestamp: now, value: 0.02, unit: "Seconds"},
+                  ),
+                )
+              end
+            end
+          end
+        end
+
+        context "when Sidekiq::Metrics is not available" do
+          subject(:publisher) do
+            Sidekiq::CloudWatchMetrics::Publisher.new(client: client, metrics: [:job_execution_time_p99])
+          end
+
+          it "silently skips the execution-histogram metrics" do
+            allow(publisher).to receive(:execution_histograms_supported?).and_return(false)
+
+            publisher.publish
+
+            expect(client).not_to have_received(:put_metric_data)
           end
         end
 

--- a/spec/sidekiq/cloudwatchmetrics_spec.rb
+++ b/spec/sidekiq/cloudwatchmetrics_spec.rb
@@ -533,7 +533,16 @@ RSpec.describe Sidekiq::CloudWatchMetrics do
       end
 
       context "when per process metrics are disabled" do
-        subject(:publisher) { Sidekiq::CloudWatchMetrics::Publisher.new(client: client, process_metrics: false) }
+        subject(:publisher) do
+          # Silence the deprecation warning emitted at init time
+          original_stderr = $stderr
+          $stderr = StringIO.new
+          begin
+            Sidekiq::CloudWatchMetrics::Publisher.new(client: client, process_metrics: false)
+          ensure
+            $stderr = original_stderr
+          end
+        end
 
         it "only publishes a single Utilization metric" do
           Timecop.freeze(now = Time.now) do
@@ -551,6 +560,113 @@ RSpec.describe Sidekiq::CloudWatchMetrics do
                 },
               )
             }
+          end
+        end
+
+        it "emits a deprecation warning" do
+          expect {
+            Sidekiq::CloudWatchMetrics::Publisher.new(client: client, process_metrics: false)
+          }.to output(/`process_metrics:` is deprecated/).to_stderr
+        end
+      end
+
+      context "with a metrics filter" do
+        context "selecting only a single global metric" do
+          subject(:publisher) { Sidekiq::CloudWatchMetrics::Publisher.new(client: client, metrics: [:retry_jobs]) }
+
+          it "publishes only that metric" do
+            Timecop.freeze(now = Time.now) do
+              publisher.publish
+
+              expect(client).to have_received(:put_metric_data).with(
+                namespace: "Sidekiq",
+                metric_data: [
+                  {
+                    metric_name: "RetryJobs",
+                    timestamp: now,
+                    value: 2,
+                    unit: "Count",
+                  },
+                ],
+              )
+            end
+          end
+
+          it "does not enumerate processes or queues" do
+            expect(Sidekiq::ProcessSet).not_to receive(:new)
+            expect(Sidekiq::Queue).not_to receive(:new)
+            publisher.publish
+          end
+        end
+
+        context "selecting only queue metrics" do
+          subject(:publisher) do
+            Sidekiq::CloudWatchMetrics::Publisher.new(client: client, metrics: %i[queue_size queue_latency])
+          end
+
+          it "publishes only the queue metrics, with high-resolution storage when interval < 60" do
+            publisher_with_short_interval = Sidekiq::CloudWatchMetrics::Publisher.new(
+              client: client, metrics: %i[queue_size queue_latency], interval: 10
+            )
+
+            Timecop.freeze(now = Time.now) do
+              publisher_with_short_interval.publish
+
+              expect(client).to have_received(:put_metric_data).with(
+                namespace: "Sidekiq",
+                metric_data: contain_exactly(
+                  {metric_name: "QueueSize", dimensions: [{name: "QueueName", value: "foo"}], timestamp: now, value: 1, unit: "Count", storage_resolution: 1},
+                  {metric_name: "QueueLatency", dimensions: [{name: "QueueName", value: "foo"}], timestamp: now, value: 1.23, unit: "Seconds", storage_resolution: 1},
+                  {metric_name: "QueueSize", dimensions: [{name: "QueueName", value: "bar"}], timestamp: now, value: 2, unit: "Count", storage_resolution: 1},
+                  {metric_name: "QueueLatency", dimensions: [{name: "QueueName", value: "bar"}], timestamp: now, value: 1.23, unit: "Seconds", storage_resolution: 1},
+                ),
+              )
+            end
+          end
+
+          it "does not enumerate processes" do
+            expect(Sidekiq::ProcessSet).not_to receive(:new)
+            publisher.publish
+          end
+        end
+
+        context "selecting only process_utilization" do
+          subject(:publisher) { Sidekiq::CloudWatchMetrics::Publisher.new(client: client, metrics: [:process_utilization]) }
+
+          it "does not call Sidekiq::Stats" do
+            expect(Sidekiq::Stats).not_to receive(:new)
+            publisher.publish
+          end
+
+          it "publishes only the per-process utilization metrics" do
+            Timecop.freeze(now = Time.now) do
+              publisher.publish
+
+              expect(client).to have_received(:put_metric_data).with(
+                namespace: "Sidekiq",
+                metric_data: contain_exactly(
+                  {metric_name: "Utilization", dimensions: [{name: "Hostname", value: "foo"}], timestamp: now, value: 50.0, unit: "Percent"},
+                  {metric_name: "Utilization", dimensions: [{name: "Hostname", value: "bar"}], timestamp: now, value: 10.0, unit: "Percent"},
+                ),
+              )
+            end
+          end
+        end
+
+        context "with an unknown metric" do
+          it "raises ArgumentError at init" do
+            expect {
+              Sidekiq::CloudWatchMetrics::Publisher.new(client: client, metrics: [:not_a_real_metric])
+            }.to raise_error(ArgumentError, /Unknown metric.*:not_a_real_metric/)
+          end
+        end
+
+        context "with an empty metrics array" do
+          subject(:publisher) { Sidekiq::CloudWatchMetrics::Publisher.new(client: client, metrics: []) }
+
+          it "publishes nothing" do
+            publisher.publish
+            expect(client).not_to have_received(:put_metric_data)
           end
         end
       end


### PR DESCRIPTION
## Summary

- Adds three new metric keys — `:job_execution_time_p50`, `:job_execution_time_p95`, `:job_execution_time_p99` — published per job class as `JobExecutionTimeP{50,95,99}` (Seconds, `JobClass` dimension)
- Source data is the per-class execution histograms Sidekiq 7+ already records in Redis via its built-in `Sidekiq::Metrics::ExecutionTracker` middleware — **no new per-job instrumentation, no new middleware in the job path**
- Silently skipped on Sidekiq versions that don't ship `Sidekiq::Metrics` (i.e. < 7), so the gem's 5.x/6.x compatibility is preserved

## Why

Olio currently emits a `time-taken` Seconds metric from a custom middleware (`app/jobs/middleware/job_processing.rb` → `app/services/analytics/metrics/sidekiq_job.rb`), gated to jobs ≥ 2 minutes (to control CloudWatch costs). That makes the existing `time-taken` p99 widget really "p99 among the slowest tail above 2 min" — a heavily skewed metric. Sidekiq's built-in tracker already buckets *every* job into a 26-bucket histogram in Redis with 8h retention, so we can publish a true p99 per minute at trivial cost. Once this lands we can retire the custom middleware on the API side.

## How it works

Each publisher tick, when any of the new metric keys are enabled:

1. Query `Sidekiq::Metrics::Query.new(now: Time.now - 60).top_jobs(minutes: 1)` to find which classes had activity in the **previous full minute** (querying the previous minute avoids racing the in-progress `ExecutionTracker` flush, which happens on the ~10s Sidekiq heartbeat).
2. For each class, fetch the 26-bucket histogram once via `Sidekiq::Metrics::Histogram#fetch`.
3. Walk the cumulative bucket counts to find the bucket where each percentile lands; emit the bucket's upper bound (in seconds) as the metric value. The final "Slow" bucket has an effectively infinite upper bound (`1e20`), so it's clamped to the previous bucket's upper bound (335 s) to keep the published value plottable.

Resolution is whichever `BUCKET_INTERVALS` bucket the percentile falls into — e.g. `1.1s`, `1.7s`, `2.5s`, `3.8s`. Fine for ops dashboards; not appropriate for sub-bucket precision work.

## Trade-offs / things to know

- Use on the standard 60s publisher, not on burst publishers (the source data only refreshes once per minute via the tracker's flush). The README spells this out.
- Like the rest of the gem's filtered metrics, these are part of `ALL_METRICS` so they publish by default. Pre-existing users on Sidekiq < 7 will see no change (silent skip); users on 7+ will start seeing new metrics in their namespace after upgrade.
- The "duplicate datapoints when running >1 publisher node on OSS Sidekiq" caveat from the existing comment in `enable!` applies here too. It's a pre-existing situation that this PR inherits but does not worsen — see follow-up plan below.

## Follow-up

Olio runs ~20 Sidekiq instances on OSS (no Enterprise leader hook). The existing publisher already publishes from every node and CloudWatch dedup's storage by metric+second, so storage costs aren't multiplied — but `put_metric_data` API calls are. Plan to add an opt-in `leader_election: :redis` option (Redis SETNX-with-TTL lock) in a follow-up PR that benefits **all** metrics, not just the new ones. Keeping it out of this PR to stay focused on the percentile feature.

## Test plan

- [x] `bundle exec rspec` passes on Sidekiq 8 (31 examples, 0 failures)
- [x] `BUNDLE_GEMFILE=Gemfile.sidekiq-7 bundle exec rspec` passes on Sidekiq 7 (31 examples, 0 failures)
- [x] `BUNDLE_GEMFILE=Gemfile.sidekiq-6 bundle exec rspec` passes on Sidekiq 6 — execution-histogram specs auto-skip (27 examples, 0 failures)
- [ ] Deploy to staging, point Olio's `Gemfile` at this branch, confirm `JobExecutionTimeP99` shows up in the `sidekiq-staging` CloudWatch namespace with sane values vs the existing `time-taken` widget

